### PR TITLE
chore: Docker로 백엔드 환경 제공

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,12 @@
+FROM mysql:8.0.36
+
+COPY init.sql /docker-entrypoint-initdb.d
+
+ENV MYSQL_ROOT_PASSWORD=root1234
+ENV MYSQL_DATABASE=interviewpartner
+ENV MYSQL_HOST=%
+
+CMD ["--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]
+
+HEALTHCHECK --interval=10s --timeout=30s --retries=5 \
+  CMD mysqladmin ping -h localhost -u root -p$MYSQL_ROOT_PASSWORD || exit 1

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,159 @@
+CREATE TABLE `tag`
+(
+    `id`   int                                     NOT NULL AUTO_INCREMENT,
+    `name` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `member`
+(
+    `id`          bigint                                  NOT NULL AUTO_INCREMENT,
+    `email`       varchar(100) COLLATE utf8mb4_general_ci NOT NULL,
+    `password`    varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
+    `nickname`    varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `provider`    varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
+    `provider_id` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
+    `is_active`   tinyint(1) NOT NULL DEFAULT '1',
+    `role`        varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `create_date` datetime(6) NOT NULL,
+    `update_date` datetime(6) NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `UK_EMAIL` (`email`),
+    UNIQUE KEY `UK_NICKNAME` (`nickname`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `resume`
+(
+    `id`                   bigint                                  NOT NULL AUTO_INCREMENT,
+    `member_id`            bigint                                  NOT NULL,
+    `original_file_name`   varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `stored_file_name`     varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `file_path`            varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `translated_file_path` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `is_active`            tinyint(1) NOT NULL DEFAULT '1',
+    `create_date`          datetime(6) NOT NULL,
+    `update_date`          datetime(6) NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY                    `idx_resume_member_id` (`member_id`),
+    CONSTRAINT `fk_resume_member` FOREIGN KEY (`member_id`) REFERENCES `member` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `interview`
+(
+    `id`                bigint                                  NOT NULL AUTO_INCREMENT,
+    `member_id`         bigint                                  NOT NULL,
+    `resume_id`         bigint                                  NOT NULL,
+    `title`             varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `job_advertisement` text COLLATE utf8mb4_general_ci,
+    `create_date`       datetime(6) NOT NULL,
+    `update_date`       datetime(6) NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY                 `idx_interview_resume_id` (`resume_id`),
+    KEY                 `idx_interview_member_id` (`member_id`),
+    CONSTRAINT `fk_interview_resume` FOREIGN KEY (`resume_id`) REFERENCES `resume` (`id`),
+    CONSTRAINT `fk_interview_member` FOREIGN KEY (`member_id`) REFERENCES `member` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `room`
+(
+    `id`               bigint                                  NOT NULL AUTO_INCREMENT,
+    `owner_id`         bigint                                  NOT NULL,
+    `title`            varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `details`          varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `max_participants` int                                     NOT NULL,
+    `session_id`       varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `status`           varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `create_date`      datetime(6) NOT NULL,
+    `update_date`      datetime(6) NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY                `idx_room_owner_id` (`owner_id`),
+    CONSTRAINT `fk_room_owner` FOREIGN KEY (`owner_id`) REFERENCES `member` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `room_tag`
+(
+    `id`      int    NOT NULL AUTO_INCREMENT,
+    `room_id` bigint NOT NULL,
+    `tag_id`  int    NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_room_tag` (`room_id`,`tag_id`),
+    KEY       `idx_room_tag_tag_id` (`tag_id`),
+    CONSTRAINT `fk_room_tag_room` FOREIGN KEY (`room_id`) REFERENCES `room` (`id`),
+    CONSTRAINT `fk_room_tag_tag` FOREIGN KEY (`tag_id`) REFERENCES `tag` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `room_participant`
+(
+    `id`         int    NOT NULL AUTO_INCREMENT,
+    `room_id`    bigint NOT NULL,
+    `member_id`  bigint NOT NULL,
+    `resume_id`  bigint NOT NULL,
+    `join_date`  datetime(6) NOT NULL,
+    `leave_date` datetime(6) DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY          `idx_room_participant_room_id` (`room_id`),
+    KEY          `idx_room_participant_member_id` (`member_id`),
+    KEY          `idx_room_participant_resume_id` (`resume_id`),
+    CONSTRAINT `fk_room_participant_room` FOREIGN KEY (`room_id`) REFERENCES `room` (`id`),
+    CONSTRAINT `fk_room_participant_member` FOREIGN KEY (`member_id`) REFERENCES `member` (`id`),
+    CONSTRAINT `fk_room_participant_resume` FOREIGN KEY (`resume_id`) REFERENCES `resume` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `question`
+(
+    `id`           bigint                                  NOT NULL AUTO_INCREMENT,
+    `interview_id` bigint                                  NOT NULL,
+    `parent_id`    bigint DEFAULT NULL,
+    `content`      varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `model_answer` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `create_date`  datetime(6) NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY            `idx_question_parent_id` (`parent_id`),
+    KEY            `idx_question_interview_id` (`interview_id`),
+    CONSTRAINT `fk_question_interview` FOREIGN KEY (`interview_id`) REFERENCES `interview` (`id`),
+    CONSTRAINT `fk_question_parent` FOREIGN KEY (`parent_id`) REFERENCES `question` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `user_answer`
+(
+    `id`          bigint                                  NOT NULL AUTO_INCREMENT,
+    `question_id` bigint                                  NOT NULL,
+    `content`     varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `audio_path`  varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
+    `create_date` datetime(6) NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY           `idx_user_answer_question_id` (`question_id`),
+    CONSTRAINT `fk_user_answer_question` FOREIGN KEY (`question_id`) REFERENCES `question` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `message`
+(
+    `id`          int                                     NOT NULL AUTO_INCREMENT,
+    `room_id`     bigint                                  NOT NULL,
+    `sender_id`   bigint                                  NOT NULL,
+    `content`     varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `create_date` datetime(6) NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY           `idx_message_sender_id` (`sender_id`),
+    KEY           `idx_message_room_id` (`room_id`),
+    CONSTRAINT `fk_message_sender` FOREIGN KEY (`sender_id`) REFERENCES `member` (`id`),
+    CONSTRAINT `fk_message_room` FOREIGN KEY (`room_id`) REFERENCES `room` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `feedback`
+(
+    `id`          bigint                          NOT NULL AUTO_INCREMENT,
+    `room_id`     bigint                          NOT NULL,
+    `sender_id`   bigint                          NOT NULL,
+    `receiver_id` bigint                          NOT NULL,
+    `content`     text COLLATE utf8mb4_general_ci NOT NULL,
+    `create_date` datetime(6) NOT NULL,
+    `update_date` datetime(6) NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY           `idx_feedback_room_id` (`room_id`),
+    KEY           `idx_feedback_sender_id` (`sender_id`),
+    KEY           `idx_feedback_receiver_id` (`receiver_id`),
+    CONSTRAINT `fk_feedback_room` FOREIGN KEY (`room_id`) REFERENCES `room` (`id`),
+    CONSTRAINT `fk_feedback_sender` FOREIGN KEY (`sender_id`) REFERENCES `member` (`id`),
+    CONSTRAINT `fk_feedback_receiver` FOREIGN KEY (`receiver_id`) REFERENCES `member` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,43 @@
+services:
+  db:
+    container_name: db-container
+    build:
+      context: ./db
+      dockerfile: Dockerfile
+    restart: always
+    ports:
+      - 3306:3306
+    environment:
+      TZ: "Asia/Seoul"
+    volumes:
+      - db:/var/lib/mysql
+    command:
+      - --default-authentication-plugin=mysql_native_password
+      - --log-error-verbosity=1
+    networks:
+      - network
+
+  server:
+    container_name: server-container
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+    restart: always
+    ports:
+      - 8080:8080
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/interviewpartner?useSSL=false&serverTimezone=UTC&useLegacyDatetimeCode=false&allowPublicKeyRetrieval=true
+      SPRING_DATASOURCE_DRIVER: com.mysql.cj.jdbc.Driver
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: root1234
+    networks:
+      - network
+
+volumes:
+  db:
+
+networks:
+  network:

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -27,6 +27,7 @@ out/
 !**/src/test/**/out/
 **/application.properties
 **/application.yml
+**/application-*.yml
 
 ### NetBeans ###
 /nbproject/private/

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,18 @@
+FROM openjdk:17-jdk-slim
+
+WORKDIR /app
+
+# COPY만 docker-compose 파일의 위치를 기반으로 작동함
+COPY . .
+
+# 개행문자 오류 해결 [unix와 window 시스템 차이]
+RUN sed -i 's/\r$//' gradlew
+
+# RUN은 현재 파일을 위치를 기반으로 작동함
+RUN chmod +x ./gradlew
+RUN ./gradlew clean build
+
+ENV JAR_PATH=/app/build/libs
+RUN mv ${JAR_PATH}/*.jar /app/app.jar
+
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=dev", "app.jar"]

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -29,10 +29,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jar {
+	enabled = false
 }

--- a/server/src/main/java/com/vip/interviewpartner/config/SecurityConfig.java
+++ b/server/src/main/java/com/vip/interviewpartner/config/SecurityConfig.java
@@ -2,12 +2,16 @@ package com.vip.interviewpartner.config;
 
 import static org.springframework.http.HttpMethod.POST;
 
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 /**
  * Spring Security 설정 클래스입니다.
@@ -27,6 +31,24 @@ public class SecurityConfig {
      */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        //cors 설정
+        http.cors((cors) -> cors
+                .configurationSource(new CorsConfigurationSource() {
+                    @Override
+                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+                        CorsConfiguration configuration = new CorsConfiguration();
+                        configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
+                        configuration.setAllowedMethods(Collections.singletonList("*"));
+                        configuration.setAllowCredentials(true);
+                        configuration.setAllowedHeaders(Collections.singletonList("*"));
+                        configuration.setMaxAge(3600L);
+
+                        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+
+                        return configuration;
+                    }
+                }));
+
         http
                 .csrf((auth) -> auth.disable());
         http


### PR DESCRIPTION
## Overview
- 프론트에서 간편하게 Docker를 이용하여 별다른 환경설정 없이 서버 API 테스트를 할 수 있습니다.
- 프론트 통신을 위해 서버 CORS 설정을 했습니다.
- Mysql 이미지를 만드는 Dockerfile을 작성하였습니다.
- Spring 이미지를 만드는 Dockerfile을 작성하였습니다.
- 생성된 이미지로 컨테이너를 띄우는 docker-compose 작성하였습니다.

## Change Log
- server/Dockerfile 추가
- db/init.sql , db/Dockerfile 추가
- docker-compose.dev.yml 추가
- SecurityConfig 수정

## To Reviewer
- application.yml 은 local, dev, prod로 나눠 .gitignore 추가하였습니다.

## Issue Tags
- Closed: #9
