### PR TITLE
feat: JWT 토큰 재발행 API 작성

### DIFF
--- a/server/src/main/java/com/vip/interviewpartner/common/constants/Constants.java
+++ b/server/src/main/java/com/vip/interviewpartner/common/constants/Constants.java
@@ -11,6 +11,7 @@ public final class Constants {
     //JWT 토큰
     public static final String ACCESS = "access";
     public static final String REFRESH = "refresh";
+    public static final String REFRESH_TOKEN = "refreshToken";
     public static final long ACCESS_TOKEN_EXPIRATION_TIME = 1800000L; // 30분
     public static final long REFRESH_TOKEN_EXPIRATION_TIME = 1209600000L; // 2주
     public static final String AUTHORIZATION_HEADER = "Authorization";

--- a/server/src/main/java/com/vip/interviewpartner/common/exception/ErrorCode.java
+++ b/server/src/main/java/com/vip/interviewpartner/common/exception/ErrorCode.java
@@ -16,9 +16,10 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(409, "Email is already in use."),
     DUPLICATE_NICKNAME(409, "Nickname is already in use."),
     LOGIN_FAILURE(401, "로그인에 실패했습니다."),
-    REFRESH_TOKEN_EXPIRED(401, "리프레쉬 토큰이 만료되었습니다."),
     ACCESS_TOKEN_EXPIRED(401, "엑세스 토큰이 만료되었습니다."),
-    INVALID_TOKEN(401, "유효하지 않는 토큰입니다.");
+    REFRESH_TOKEN_EXPIRED(401, "리프레쉬 토큰이 만료되었습니다."),
+    INVALID_TOKEN(401, "유효하지 않는 토큰입니다."),
+    REFRESH_TOKEN_NOT_EXIST(401, "리프레쉬 토큰이 존재하지 않습니다.");
 
     private final int status;
     private final String message;

--- a/server/src/main/java/com/vip/interviewpartner/common/jwt/JWTFilter.java
+++ b/server/src/main/java/com/vip/interviewpartner/common/jwt/JWTFilter.java
@@ -3,16 +3,12 @@ package com.vip.interviewpartner.common.jwt;
 import static com.vip.interviewpartner.common.constants.Constants.ACCESS;
 import static com.vip.interviewpartner.common.constants.Constants.AUTHORIZATION_HEADER;
 import static com.vip.interviewpartner.common.constants.Constants.BEARER_TOKEN_PREFIX;
-import static com.vip.interviewpartner.common.exception.ErrorCode.ACCESS_TOKEN_EXPIRED;
 import static com.vip.interviewpartner.common.exception.ErrorCode.INVALID_REQUEST;
-import static com.vip.interviewpartner.common.exception.ErrorCode.INVALID_TOKEN;
 
 import com.vip.interviewpartner.common.exception.CustomException;
 import com.vip.interviewpartner.domain.Member;
 import com.vip.interviewpartner.domain.Role;
 import com.vip.interviewpartner.dto.CustomUserDetails;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -54,22 +50,8 @@ public class JWTFilter extends OncePerRequestFilter {
         }
 
         String accessToken = authorization.split(" ")[1];
-
-        try {
-            jwtUtil.isExpired(accessToken);
-        } catch (ExpiredJwtException e) {
-            throw new CustomException(ACCESS_TOKEN_EXPIRED);
-        } catch (JwtException e) {
-            throw new CustomException(INVALID_TOKEN);
-        } catch (Exception e) {
-            throw new CustomException(INVALID_REQUEST);
-        }
-
-        String category = jwtUtil.getCategory(accessToken);
-
-        if (!category.equals(ACCESS)) {
-            throw new CustomException(INVALID_REQUEST);
-        }
+        jwtUtil.validateToken(accessToken);
+        jwtUtil.validateCategory(accessToken, ACCESS);
 
         Long id = jwtUtil.getId(accessToken);
         String nickname = jwtUtil.getNickname(accessToken);

--- a/server/src/main/java/com/vip/interviewpartner/common/jwt/JWTUtil.java
+++ b/server/src/main/java/com/vip/interviewpartner/common/jwt/JWTUtil.java
@@ -4,7 +4,12 @@ import static com.vip.interviewpartner.common.constants.Constants.ACCESS;
 import static com.vip.interviewpartner.common.constants.Constants.ACCESS_TOKEN_EXPIRATION_TIME;
 import static com.vip.interviewpartner.common.constants.Constants.REFRESH;
 import static com.vip.interviewpartner.common.constants.Constants.REFRESH_TOKEN_EXPIRATION_TIME;
+import static com.vip.interviewpartner.common.exception.ErrorCode.ACCESS_TOKEN_EXPIRED;
+import static com.vip.interviewpartner.common.exception.ErrorCode.INVALID_REQUEST;
+import static com.vip.interviewpartner.common.exception.ErrorCode.INVALID_TOKEN;
 
+import com.vip.interviewpartner.common.exception.CustomException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -52,13 +57,37 @@ public class JWTUtil {
     }
 
     /**
-     * JWT 토큰의 만료 여부를 확인합니다.
+     * 주어진 토큰이 유효성 검증을 합니다.
+     * 토큰이 만료되었을 경우, ACCESS_TOKEN_EXPIRED 예외를 발생시킵니다.
+     * 토큰이 유효하지 않거나 요청이 잘못된 경우, 각각 INVALID_TOKEN, INVALID_REQUEST 예외를 발생시킵니다.
      *
-     * @param token JWT 토큰
-     * @return 토큰이 만료되었으면 true, 그렇지 않으면 false
+     * @param token 검증할 JWT 토큰
+     * @throws CustomException 토큰이 만료되었거나 유효하지 않은 경우, 또는 잘못된 요청인 경우 발생합니다.
      */
-    public Boolean isExpired(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    public void validateToken(String token) {
+        try {
+            if (isExpired(token)) {
+                throw new CustomException(ACCESS_TOKEN_EXPIRED);
+            }
+        } catch (JwtException e) {
+            throw new CustomException(INVALID_TOKEN);
+        } catch (Exception e) {
+            throw new CustomException(INVALID_REQUEST);
+        }
+    }
+
+    /**
+     * 주어진 토큰의 카테고리를 검증합니다. 카테고리가 주어진 카테고리와 일치하지 않는 경우, INVALID_REQUEST 예외를 발생시킵니다.
+     *
+     * @param token            검증할 JWT 토큰
+     * @param expectedCategory 기대하는 카테고리
+     * @throws CustomException 카테고리가 기대하는 카테고리와 일치하지 않는 경우
+     */
+    public void validateCategory(String token, String expectedCategory) {
+        String category = getCategory(token);
+        if (!category.equals(expectedCategory)) {
+            throw new CustomException(INVALID_REQUEST);
+        }
     }
 
     /**
@@ -99,6 +128,16 @@ public class JWTUtil {
                 .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION_TIME))
                 .signWith(secretKey)
                 .compact();
+    }
+
+    /**
+     * JWT 토큰의 만료 여부를 확인합니다.
+     *
+     * @param token JWT 토큰
+     * @return 토큰이 만료되었으면 true, 그렇지 않으면 false
+     */
+    private Boolean isExpired(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
 }

--- a/server/src/main/java/com/vip/interviewpartner/common/jwt/LoginFilter.java
+++ b/server/src/main/java/com/vip/interviewpartner/common/jwt/LoginFilter.java
@@ -2,7 +2,7 @@ package com.vip.interviewpartner.common.jwt;
 
 import static com.vip.interviewpartner.common.constants.Constants.AUTHORIZATION_HEADER;
 import static com.vip.interviewpartner.common.constants.Constants.BEARER_TOKEN_PREFIX;
-import static com.vip.interviewpartner.common.constants.Constants.REFRESH;
+import static com.vip.interviewpartner.common.constants.Constants.REFRESH_TOKEN;
 import static com.vip.interviewpartner.common.exception.ErrorCode.INVALID_REQUEST;
 import static com.vip.interviewpartner.common.exception.ErrorCode.LOGIN_FAILURE;
 
@@ -87,7 +87,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String refreshToken = tokenService.createRefreshToken(member);
 
         response.setHeader(AUTHORIZATION_HEADER, BEARER_TOKEN_PREFIX + accessToken);
-        response.addCookie(tokenService.createCookie(REFRESH, refreshToken));
+        response.addCookie(tokenService.createRefreshTokenCookie(REFRESH_TOKEN, refreshToken));
         response.setStatus(HttpStatus.OK.value());
         sendSuccessResponse(response);
         log.info("login success");

--- a/server/src/main/java/com/vip/interviewpartner/config/SecurityConfig.java
+++ b/server/src/main/java/com/vip/interviewpartner/config/SecurityConfig.java
@@ -85,7 +85,7 @@ public class SecurityConfig {
                         .accessDeniedHandler(customAccessDeniedHandler));
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers(POST, "/api/v1/members").permitAll()
+                        .requestMatchers(POST, "/api/v1/members", "/api/v1/auth/token/reissue").permitAll()
                         .requestMatchers(GET, "/api/v1/members/check/nickname/*").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/api/v1/swagger-ui/**", "/api/v1/docs").permitAll()
                         .anyRequest().authenticated());

--- a/server/src/main/java/com/vip/interviewpartner/config/SpringDocConfig.java
+++ b/server/src/main/java/com/vip/interviewpartner/config/SpringDocConfig.java
@@ -16,6 +16,9 @@ import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.customizers.OpenApiCustomizer;
@@ -43,12 +46,22 @@ public class SpringDocConfig {
      */
     @Bean
     public OpenAPI openAPI() {
+        final String securitySchemeName = "bearerAuth";
+
         Info info = new Info()
                 .title("Interview Partner API Document")
                 .version("v1.0.0")
                 .description("Interview Partner API 명세서입니다.");
         OpenAPI openAPI = new OpenAPI()
-                .components(new Components())
+                .addSecurityItem(new SecurityRequirement()
+                        .addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                                .name(securitySchemeName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .description("로그인 API를 호출해 받은 accessToken을 입력해주세요. refreshToken은 쿠키로 전달됩니다.")
+                                .bearerFormat("JWT")))
                 .info(info)
                 .paths(new Paths());
 
@@ -103,6 +116,7 @@ public class SpringDocConfig {
                     operation.responses(apiResponses);
                     operation.addTagsItem("auth");
                     operation.description("로그인");
+                    operation.setSecurity(List.of());
                     operation.summary("로그인 API");
                     PathItem pathItem = new PathItem().post(operation);
                     openAPI.getPaths().addPathItem("/api/v1/auth/login", pathItem);

--- a/server/src/main/java/com/vip/interviewpartner/controller/AuthController.java
+++ b/server/src/main/java/com/vip/interviewpartner/controller/AuthController.java
@@ -1,21 +1,67 @@
 package com.vip.interviewpartner.controller;
 
+import static com.vip.interviewpartner.common.constants.Constants.ACCESS;
+import static com.vip.interviewpartner.common.constants.Constants.AUTHORIZATION_HEADER;
+import static com.vip.interviewpartner.common.constants.Constants.BEARER_TOKEN_PREFIX;
+import static com.vip.interviewpartner.common.constants.Constants.REFRESH;
+import static com.vip.interviewpartner.common.constants.Constants.REFRESH_TOKEN;
+
+import com.vip.interviewpartner.common.ApiCommonResponse;
+import com.vip.interviewpartner.dto.CustomUserDetails;
+import com.vip.interviewpartner.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 @Tag(name = "auth", description = "인증 API")
-@Slf4j
 public class AuthController {
+
+    private final TokenService tokenService;
+
+    @Operation(summary = "토큰 재발행 API",
+            description = "JWT 토큰 재발행",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "토큰 재발행 성공 - 헤더에 'Authorization'로 새로운 엑세스 토큰이 포함되어 있으며, " +
+                            "'Set-Cookie' 헤더를 통해 새로운 리프레쉬 토큰이 쿠키로 설정됩니다.",
+                            headers = {
+                                    @Header(name = "Authorization", description = "Bearer [access token]", schema = @Schema(type = "string")),
+                                    @Header(name = "Set-Cookie", description = "refreshToken=[token]; Path=/; HttpOnly", schema = @Schema(type = "string"))
+                            }),
+                    @ApiResponse(responseCode = "400", description = "유효한 요청이 아님", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "리프레쉬 토큰 만료, 토큰 없음, 유효하지 않는 토큰 - 사용자가 새로운 로그인을 요청해야 합니다.", content = @Content),
+            }
+    )
+    @SecurityRequirements(value = {})
+    @PostMapping("/token/reissue")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiCommonResponse<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+        String findRefreshToken = tokenService.getRefreshTokenFromCookie(request.getCookies());
+        Map<String, String> newTokens = tokenService.reissue(findRefreshToken);
+        Cookie refreshTokenCookie = tokenService.createRefreshTokenCookie(REFRESH_TOKEN, newTokens.get(REFRESH));
+        response.setHeader(AUTHORIZATION_HEADER, BEARER_TOKEN_PREFIX + newTokens.get(ACCESS));
+        response.addCookie(refreshTokenCookie);
+        return ApiCommonResponse.successWithNoContent();
+    }
+
     @Operation(summary = "인증 테스트 API",
             description = "테스트",
             responses = {
@@ -24,7 +70,8 @@ public class AuthController {
             }
     )
     @GetMapping("/test")
-    public String hello() {
-        return "당신은 인증된 사용자입니다.";
+    @ResponseStatus(HttpStatus.OK)
+    public ApiCommonResponse<String> hello(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ApiCommonResponse.successResponse("안녕하세요 닉네임: " + customUserDetails.getNickname() + "은 인증된 사용자 입니다.");
     }
 }

--- a/server/src/main/java/com/vip/interviewpartner/controller/MemberController.java
+++ b/server/src/main/java/com/vip/interviewpartner/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.vip.interviewpartner.service.MemberJoinService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -51,6 +52,7 @@ public class MemberController {
                     @ApiResponse(responseCode = "409", description = "이메일 및 닉네임 중복 에러", content = @Content),
             }
     )
+    @SecurityRequirements(value = {})
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ApiCommonResponse<?> addMember(@Valid @RequestBody final MemberJoinRequest memberJoinRequest) {
@@ -59,8 +61,7 @@ public class MemberController {
     }
 
     /**
-     * 닉네임 중복확인 API입니다.
-     * 닉네임이 사용 가능한 경우 true를, 그렇지 않을 경우 false를 담아서 반환합니다.
+     * 닉네임 중복확인 API입니다. 닉네임이 사용 가능한 경우 true를, 그렇지 않을 경우 false를 담아서 반환합니다.
      *
      * @param nickname 확인할 닉네임
      * @return ApiCommonResponse.successResponse();
@@ -72,6 +73,7 @@ public class MemberController {
                     @ApiResponse(responseCode = "400", description = "유효한 형식이 아님", content = @Content),
             }
     )
+    @SecurityRequirements(value = {})
     @GetMapping("/check/nickname/{nickname}")
     @ResponseStatus(HttpStatus.OK)
     public ApiCommonResponse<NicknameCheckResponse> checkNickname(@NotBlank @Size(min = 2, max = 10) @PathVariable String nickname) {

--- a/server/src/main/java/com/vip/interviewpartner/dto/CustomUserDetails.java
+++ b/server/src/main/java/com/vip/interviewpartner/dto/CustomUserDetails.java
@@ -62,6 +62,10 @@ public class CustomUserDetails implements UserDetails {
         return member.isActive();
     }
 
+    public Long getMemberId() {
+        return member.getId();
+    }
+
     public String getNickname() {
         return member.getNickname();
     }

--- a/server/src/main/java/com/vip/interviewpartner/dto/MemberJoinRequest.java
+++ b/server/src/main/java/com/vip/interviewpartner/dto/MemberJoinRequest.java
@@ -19,12 +19,12 @@ import lombok.NoArgsConstructor;
 @Schema(description = "회원가입 요청 DTO")
 public class MemberJoinRequest {
 
-    @Schema(description = "이메일", example = "asdasd@google.com")
+    @Schema(description = "이메일", example = "user@example.com")
     @NotBlank(message = "이메일은 필수입니다.")
     @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
 
-    @Schema(description = "비밀번호", example = "q1w2e3r4")
+    @Schema(description = "비밀번호", example = "yourpassword")
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Size(min = 8, max = 12, message = "비밀번호는 8자 이상, 12자 이하여야 합니다.")
     private String password;

--- a/server/src/main/java/com/vip/interviewpartner/repository/RefreshTokenRepository.java
+++ b/server/src/main/java/com/vip/interviewpartner/repository/RefreshTokenRepository.java
@@ -3,6 +3,8 @@ package com.vip.interviewpartner.repository;
 import static com.vip.interviewpartner.common.constants.Constants.REFRESH_TOKEN_EXPIRATION_TIME;
 
 import com.vip.interviewpartner.dto.RefreshTokenData;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +18,6 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 @RequiredArgsConstructor
-@Slf4j
 public class RefreshTokenRepository {
 
     private final RedisTemplate redisTemplate;
@@ -32,6 +33,33 @@ public class RefreshTokenRepository {
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
         valueOperations.set(refreshTokenData.getRefreshToken(), refreshTokenData.getMemberId());
         redisTemplate.expire(refreshTokenData.getRefreshToken(), REFRESH_TOKEN_EXPIRATION_TIME, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * 이 메소드는 주어진 refreshToken으로 Redis에서 memberId를 찾습니다.
+     * memberId가 존재하면 RefreshTokenData 객체를 반환하고, 그렇지 않으면 빈 Optional 객체를 반환합니다.
+     *
+     * @param refreshToken 찾을 refreshToken
+     * @return Optional<RefreshTokenData> memberId가 존재하면 RefreshTokenData 객체를 포함하는 Optional, 그렇지 않으면 빈 Optional
+     */
+    public Optional<RefreshTokenData> findByRefreshToken(final String refreshToken) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        String memberId = valueOperations.get(refreshToken);
+
+        if (Objects.isNull(memberId)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new RefreshTokenData(refreshToken, memberId));
+    }
+
+    /**
+     * 이 메소드는 주어진 refreshToken을 Redis에서 삭제합니다.
+     *
+     * @param refreshToken 삭제할 refreshToken
+     */
+    public void deleteByRefreshToken(final String refreshToken) {
+        redisTemplate.delete(refreshToken);
     }
 
 }

--- a/server/src/main/java/com/vip/interviewpartner/service/TokenService.java
+++ b/server/src/main/java/com/vip/interviewpartner/service/TokenService.java
@@ -1,11 +1,19 @@
 package com.vip.interviewpartner.service;
 
-import com.vip.interviewpartner.common.constants.Constants;
+import static com.vip.interviewpartner.common.constants.Constants.ACCESS;
+import static com.vip.interviewpartner.common.constants.Constants.COOKIE_REFRESH_EXPIRATION_SECONDS;
+import static com.vip.interviewpartner.common.constants.Constants.REFRESH;
+import static com.vip.interviewpartner.common.constants.Constants.REFRESH_TOKEN;
+import static com.vip.interviewpartner.common.exception.ErrorCode.INVALID_TOKEN;
+import static com.vip.interviewpartner.common.exception.ErrorCode.REFRESH_TOKEN_NOT_EXIST;
+
+import com.vip.interviewpartner.common.exception.CustomException;
 import com.vip.interviewpartner.common.jwt.JWTUtil;
 import com.vip.interviewpartner.domain.Member;
 import com.vip.interviewpartner.dto.RefreshTokenData;
 import com.vip.interviewpartner.repository.RefreshTokenRepository;
 import jakarta.servlet.http.Cookie;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -44,18 +52,60 @@ public class TokenService {
     /**
      * 주어진 키와 값으로 쿠키를 생성합니다.
      *
-     * @param key 쿠키의 키
+     * @param key   쿠키의 키
      * @param value 쿠키의 값
      * @return 생성된 쿠키
      */
-    public Cookie createCookie(String key, String value) {
+    public Cookie createRefreshTokenCookie(String key, String value) {
         Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(Constants.COOKIE_REFRESH_EXPIRATION_SECONDS);
+        cookie.setMaxAge(COOKIE_REFRESH_EXPIRATION_SECONDS);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
         // cookie.setSecure(true); // HTTPS 사용 시 주석 해제
         return cookie;
     }
 
+    /**
+     * 주어진 쿠키 배열에서 'refreshToken' 쿠키를 찾아 반환하는 메소드입니다.
+     *
+     * @param cookies 클라이언트로부터 받은 쿠키 배열
+     * @return 찾은 'refreshToken' 쿠키
+     * @throws CustomException 'refreshToken' 쿠키가 없는 경우, cookies[]이 null인 경우
+     */
+    public String getRefreshTokenFromCookie(Cookie[] cookies) {
+        if (cookies == null) {
+            throw new CustomException(REFRESH_TOKEN_NOT_EXIST);
+        }
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(REFRESH_TOKEN)) {
+                return cookie.getValue();
+            }
+        }
+        throw new CustomException(REFRESH_TOKEN_NOT_EXIST);
+    }
+
+    /**
+     * 주어진 리프레쉬 토큰을 바탕으로 새로운 엑세스 토큰과 리프레쉬 토큰을 발급하는 메소드입니다.
+     * 이 메소드는 주어진 리프레쉬 토큰의 유효성을 검증하고, 새로운 엑세스 토큰과 리프레쉬 토큰을 생성합니다.
+     * 기존의 리프레쉬 토큰을 Redis에서 삭제하고 새로운 리프레쉬 토큰을 저장합니다.
+     *
+     * @param findRefreshToken 유효성을 검증할 리프레쉬 토큰
+     * @return 새로 생성된 엑세스 토큰과 리프레쉬 토큰을 담은 Map 객체
+     * @throws CustomException 리프레쉬 토큰이 유효하지 않은 경우, 리프레쉬 토큰이 존재하지 않는 경우
+     */
+    public Map<String, String> reissue(String findRefreshToken) {
+        jwtUtil.validateToken(findRefreshToken);
+        jwtUtil.validateCategory(findRefreshToken, REFRESH);
+        String memberId = refreshTokenRepository.findByRefreshToken(findRefreshToken).orElseThrow(() -> new CustomException(INVALID_TOKEN)).getMemberId();
+        String nickname = jwtUtil.getNickname(findRefreshToken);
+        String role = jwtUtil.getRole(findRefreshToken);
+
+        String newAccessToken = jwtUtil.createAccessToken(Long.valueOf(memberId), nickname, role);
+        String newRefreshToken = jwtUtil.createRefreshToken(Long.valueOf(memberId), nickname, role);
+
+        refreshTokenRepository.deleteByRefreshToken(findRefreshToken);
+        refreshTokenRepository.save(new RefreshTokenData(newRefreshToken, memberId));
+        return Map.of(ACCESS, newAccessToken, REFRESH, newRefreshToken);
+    }
 }
 


### PR DESCRIPTION
## Overview
- Access Token 이 만료가 되면 Refresh Token으로 토큰을 재발행하는 API를 추가하였습니다.
- 보안을 강화하기위해 Refresh Rotate 기법을 사용하였습니다.
- 토큰의 유효성검증 하는 부분이 중복되는 부분이 있어 TokenService에 함수로 따로 분리해 리팩토링 진행하였습니다.
> **Refresh Rotate**: Refresh 토큰으로 Access 토큰 갱신 시 Refresh 토큰도 함께 갱신하는 방법

## Change Log
- TokenService 수정
- RefrshTokenRepository 수정
- JWTUtil, JWTFilter 수정
- AuthController 수정 

## To Reviewer
- JWT 토큰 하나만 사용할 때의 단점을 개선하기 위해 리프레시 토큰을 도입했습니다.
- 기존 토큰은 서버가 통제할 수 없어 토큰이 탈취되었을 경우 대처가 불가능했습니다. 이를 해결하기 위해 리프레시 토큰을 서버에서 관리하도록 변경하였습니다.
- 이 변경으로 서버에 토큰을 저장하게 되며, 토큰 탈취 시 즉시 로그아웃 조치와 같은 즉각적인 대응이 가능해졌고, 향후 블랙리스트 관리가 용이해질 것입니다.
- 또한 보안 강화를 위해 토큰 재발행시, 새로운 액세스토큰과 리프레쉬토큰을 발급하는 방식을 사용했습니다.

이에 JWT 흐름에 관련해서 의견이나 궁금한거 있으시면 말씀해주세요!

## Issue Tags
- Closed: #18
