### PR TITLE
feat: 모의면접 방 태그 검색 API 작성

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -1,8 +1,10 @@
 CREATE TABLE `tag`
 (
-    `id`   int                                     NOT NULL AUTO_INCREMENT,
-    `name` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
-    PRIMARY KEY (`id`)
+    `id`         int                                     NOT NULL AUTO_INCREMENT,
+    `name`       varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+    `usageCount` int                                     NOT NULL DEFAULT 0,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `UK_NAME` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 CREATE TABLE `member`

--- a/server/src/main/java/com/vip/interviewpartner/controller/TagController.java
+++ b/server/src/main/java/com/vip/interviewpartner/controller/TagController.java
@@ -8,21 +8,27 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
  * 태그 생성 및 관련 기능을 제공하는 컨트롤러입니다.
  */
+@Tag(name = "tags", description = "태그 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/tags")
-@Tag(name = "tags", description = "태그 API")
+@Validated
 public class TagController {
     private final TagService tagService;
 
@@ -39,5 +45,19 @@ public class TagController {
     public ApiCommonResponse<TagResponse> createTag(@RequestBody TagCreateRequest tagCreateRequest) {
         TagResponse tagResponse = tagService.create(tagCreateRequest);
         return ApiCommonResponse.successResponse(tagResponse);
+    }
+
+    @Operation(summary = "태그 검색 API",
+            description = "입력된 문자열로 시작하는 태그를 검색해 사용빈도수를 기준으로 내림차순으로 정렬합니다. size는 default 10입니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "태그 검색 성공"),
+                    @ApiResponse(responseCode = "400", description = "유효하지 않은 요청, query가 공백", content = @Content)
+            }
+    )
+    @GetMapping("/search")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiCommonResponse<List<TagResponse>> searchTags(@NotBlank @RequestParam String query, @RequestParam(defaultValue = "10") int size) {
+        List<TagResponse> tagResponses = tagService.searchTags(query, size);
+        return ApiCommonResponse.successResponse(tagResponses);
     }
 }

--- a/server/src/main/java/com/vip/interviewpartner/domain/Tag.java
+++ b/server/src/main/java/com/vip/interviewpartner/domain/Tag.java
@@ -1,5 +1,6 @@
 package com.vip.interviewpartner.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -20,9 +21,17 @@ public class Tag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
+    @Column(nullable = false, unique = true)
     private String name;
+
+    @Column(nullable = false)
+    private Integer usageCount = 0;
 
     public Tag(String name) {
         this.name = name;
+    }
+
+    public void incrementUsageCount() {
+        this.usageCount++;
     }
 }

--- a/server/src/main/java/com/vip/interviewpartner/repository/TagRepository.java
+++ b/server/src/main/java/com/vip/interviewpartner/repository/TagRepository.java
@@ -1,6 +1,8 @@
 package com.vip.interviewpartner.repository;
 
 import com.vip.interviewpartner.domain.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
@@ -14,4 +16,13 @@ public interface TagRepository extends JpaRepository<Tag, Integer> {
      * @return 해당 이름을 가진 태그가 존재하면 true, 그렇지 않으면 false
      */
     boolean existsByName(String name);
+
+    /**
+     * 주어진 문자열로 시작하는 상위 태그 목록을 사용 빈도수로 정렬하여 제한된 수로 검색합니다.
+     *
+     * @param name     태그 이름 시작 문자열
+     * @param pageable 페이지 요청 정보
+     * @return 검색된 태그 목록
+     */
+    Page<Tag> findByNameStartingWithOrderByUsageCountDesc(String name, Pageable pageable);
 }

--- a/server/src/main/java/com/vip/interviewpartner/service/TagService.java
+++ b/server/src/main/java/com/vip/interviewpartner/service/TagService.java
@@ -7,7 +7,12 @@ import com.vip.interviewpartner.domain.Tag;
 import com.vip.interviewpartner.dto.TagCreateRequest;
 import com.vip.interviewpartner.dto.TagResponse;
 import com.vip.interviewpartner.repository.TagRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,5 +39,20 @@ public class TagService {
         }
         Tag tag = tagRepository.save(new Tag(tagCreateRequest.getName()));
         return new TagResponse(tag);
+    }
+
+    /**
+     * 검색 쿼리를 기반으로 태그 목록을 검색하고, 사용 빈도(usageCount) 기준으로 내림차순 정렬하여 반환합니다.
+     *
+     * @param query 검색할 태그 이름의 접두사
+     * @param size 반환할 태그 목록의 최대 크기
+     * @return 검색된 태그 목록을 TagResponse 객체로 변환하여 반환
+     */
+    public List<TagResponse> searchTags(String query, int size) {
+        Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "usageCount"));
+        return tagRepository.findByNameStartingWithOrderByUsageCountDesc(query, pageable).getContent()
+                .stream()
+                .map(TagResponse::new)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Overview
- 모의면접 방 만들때 사용할 태그를 검색하는 API를 작성하였습니다.
- 태그 Entity에 사용빈도수 필드를 추가하였습니다.
- 주어진 문자열로 시작하는 상위 태그 목록을 사용 빈도수로 정렬하여 제한된 수로 검색합니다.

## Change Log
- TagController 수정
- TagService 수정
- TagRepository 수정
- Tag Entity 수정
- init.sql 수정 

## To Reviewer
- Tag 테이블을 만드는 쿼리에 tag name의 unique 설정과 사용빈도수 필드를 추가하였습니다. 한번 확인 부탁드릴께요!

## Issue Tags
- Closed: #43
