### PR TITLE
refactor: Native 소셜로그인 실패 동작 변경

### DIFF
--- a/server/src/main/java/com/vip/interviewpartner/common/oauth2/CustomFailureHandler.java
+++ b/server/src/main/java/com/vip/interviewpartner/common/oauth2/CustomFailureHandler.java
@@ -1,0 +1,61 @@
+package com.vip.interviewpartner.common.oauth2;
+
+import static com.vip.interviewpartner.common.exception.ErrorCode.*;
+
+import com.vip.interviewpartner.common.exception.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ * CustomFailureHandler는 OAuth2 인증 실패 시 실행되는 핸들러로,
+ * 실패한 인증 요청을 처리하고 클라이언트를 특정 URL로 리다이렉트합니다.
+ */
+@Slf4j
+@Component
+public class CustomFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    private static final String BASE_ERROR_URL = "http://localhost:3000/login?status=failure&error=";
+    private static final String DEFAULT_ERROR = "login-failed";
+
+    /**
+     * 인증 실패 시 실행되는 메서드로, 실패한 인증 요청을 처리하고 클라이언트를 특정 URL로 리다이렉트합니다.
+     *
+     * @param request  HttpServletRequest 객체
+     * @param response HttpServletResponse 객체
+     * @param exception 인증 실패 시 발생하는 AuthenticationException 객체
+     * @throws IOException 예외 처리
+     * @throws ServletException 예외 처리
+     */
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        String errorCode = determineErrorCode(exception);
+        String redirectUrl = BASE_ERROR_URL + errorCode;
+        response.sendRedirect(redirectUrl);
+        log.info("social login failure");
+    }
+
+    /**
+     * 예외 객체를 분석하여 에러 코드를 결정합니다.
+     *
+     * @param exception 인증 실패 시 발생하는 AuthenticationException 객체
+     * @return 에러 코드 문자열
+     */
+    private String determineErrorCode(AuthenticationException exception) {
+        if (exception instanceof OAuth2AuthenticationException) {
+            OAuth2AuthenticationException oauthException = (OAuth2AuthenticationException) exception;
+            OAuth2Error error = oauthException.getError();
+            if (error.getErrorCode().equals(DUPLICATE_EMAIL.name())) {
+                return DUPLICATE_EMAIL.name().toLowerCase().replace("_", "-");
+            }
+        }
+        return DEFAULT_ERROR;
+    }
+}

--- a/server/src/main/java/com/vip/interviewpartner/common/oauth2/CustomSuccessHandler.java
+++ b/server/src/main/java/com/vip/interviewpartner/common/oauth2/CustomSuccessHandler.java
@@ -23,6 +23,8 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 @RequiredArgsConstructor
 @Configuration
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private static final String SUCCESS_URL = "http://localhost:3000/login?status=success";
+
     private final TokenService tokenService;
 
     /**
@@ -40,7 +42,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         Member member = ((CustomUserDetails) authentication.getPrincipal()).getMember();
         String refresh = tokenService.createRefreshToken(member);
         response.addCookie(tokenService.createRefreshTokenCookie(REFRESH_TOKEN, refresh, COOKIE_REFRESH_EXPIRATION_SECONDS));
-        response.sendRedirect("http://localhost:3000/token/reissue"); // 임의로 지정(추후 변경)
+        response.sendRedirect(SUCCESS_URL);
         log.info("social login success");
     }
 }

--- a/server/src/main/java/com/vip/interviewpartner/config/SecurityConfig.java
+++ b/server/src/main/java/com/vip/interviewpartner/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import com.vip.interviewpartner.common.exception.ExceptionHandlingFilter;
 import com.vip.interviewpartner.common.jwt.JWTFilter;
 import com.vip.interviewpartner.common.jwt.JWTUtil;
 import com.vip.interviewpartner.common.jwt.LoginFilter;
+import com.vip.interviewpartner.common.oauth2.CustomFailureHandler;
 import com.vip.interviewpartner.common.oauth2.CustomSuccessHandler;
 import com.vip.interviewpartner.common.oauth2.FirebaseTokenFilter;
 import com.vip.interviewpartner.service.CustomOAuth2UserService;
@@ -46,6 +47,7 @@ public class SecurityConfig {
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomSuccessHandler customSuccessHandler;
+    private final CustomFailureHandler customFailureHandler;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -95,7 +97,8 @@ public class SecurityConfig {
                                 .baseUri("/api/v1/auth/login/oauth2"))
                         .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
                                 .userService(customOAuth2UserService))
-                        .successHandler(customSuccessHandler));
+                        .successHandler(customSuccessHandler)
+                        .failureHandler(customFailureHandler));
 
         http
                 .authorizeHttpRequests((auth) -> auth

--- a/server/src/main/java/com/vip/interviewpartner/config/SpringDocConfig.java
+++ b/server/src/main/java/com/vip/interviewpartner/config/SpringDocConfig.java
@@ -148,11 +148,11 @@ public class SpringDocConfig {
     private ApiResponses createOAuthResponses() {
         ApiResponses responses = new ApiResponses();
         responses.addApiResponse(String.valueOf(HttpStatus.FOUND.value()),
-                new ApiResponse().description("리다이렉션 성공, 리프레시 토큰이 쿠키에 저장되었습니다. 이 토큰을 사용하여 토큰 재발행 페이지로 리다이렉션을 해 엑세스토큰까지 받습니다."));
-        responses.addApiResponse(String.valueOf(HttpStatus.BAD_REQUEST.value()),
-                new ApiResponse().description("잘못된 요청"));
-        responses.addApiResponse(String.valueOf(HttpStatus.CONFLICT.value()),
-                new ApiResponse().description("동일한 소셜 계정으로 가입된 회원이 이미 존재합니다."));
+                new ApiResponse().description(
+                        "로그인 성공. FRONTEND_BASE_URL/login?status=success 로 리다이렉션 되어 토큰 재발행 API를 요청합니다.\n\n" +
+                        "잘못된 요청. FRONTEND_BASE_URL/login?status=failure&error=login-failed 로 리다이렉션됩니다.\n\n" +
+                        "동일한 소셜 계정으로 가입된 회원이 이미 존재. FRONTEND_BASE_URL/login?status=failure&error=duplicate-email 로 리다이렉션됩니다."
+                ));
         return responses;
     }
 


### PR DESCRIPTION
## Overview
- 현재 Native 소셜 로그인은 성공 시 서버에서 프론트 주소로 리다이렉트하는데, 실패 시에는 JSON 형태로 에러를 응답하고 있었습니다.
- 이를 성공 시와 마찬가지로 실패 시에도 리다이렉트로 프론트의 로그인 주소에 파라미터를 붙여서 처리하도록 변경했습니다.

## Change Log
- CustomOAuth2UserService 수정
- CustomSuccessHandler 수정
- CustomFailureHandler 추가

## To Reviewer
- 프론트분과 상의한 결과 이 방식으로 하기로 했으나, 한번 더 이 방식이 괜찮은지 확인 부탁드립니다.

## Issue Tags
- Closed: #46 
