### PR TITLE
feat: 모의면접 방 목록 조회 API 작성

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -2,7 +2,7 @@ CREATE TABLE `tag`
 (
     `id`         int                                     NOT NULL AUTO_INCREMENT,
     `name`       varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
-    `usageCount` int                                     NOT NULL DEFAULT 0,
+    `usage_count` int                                     NOT NULL DEFAULT 0,
     PRIMARY KEY (`id`),
     UNIQUE KEY `UK_NAME` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,7 +40,7 @@ services:
       db:
         condition: service_healthy
     environment:
-      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/interviewpartner?useSSL=false&serverTimezone=UTC&useLegacyDatetimeCode=false&allowPublicKeyRetrieval=true
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/interviewpartner?useSSL=false&serverTimezone=Asia/Seoul&useLegacyDatetimeCode=false&allowPublicKeyRetrieval=true
       SPRING_DATASOURCE_DRIVER: com.mysql.cj.jdbc.Driver
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: root1234

--- a/server/src/main/java/com/vip/interviewpartner/config/SecurityConfig.java
+++ b/server/src/main/java/com/vip/interviewpartner/config/SecurityConfig.java
@@ -103,7 +103,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers(POST, "/api/v1/members", "/api/v1/auth/token/reissue").permitAll()
-                        .requestMatchers(GET, "/api/v1/members/check/nickname/*").permitAll()
+                        .requestMatchers(GET, "/api/v1/members/check/nickname/*", "/api/v1/rooms").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/api/v1/swagger-ui/**", "/api/v1/docs").permitAll()
                         .anyRequest().authenticated());
 

--- a/server/src/main/java/com/vip/interviewpartner/controller/RoomController.java
+++ b/server/src/main/java/com/vip/interviewpartner/controller/RoomController.java
@@ -1,21 +1,33 @@
 package com.vip.interviewpartner.controller;
 
 import com.vip.interviewpartner.common.ApiCommonResponse;
+import com.vip.interviewpartner.domain.RoomStatus;
 import com.vip.interviewpartner.dto.CustomUserDetails;
 import com.vip.interviewpartner.dto.RoomCreateRequest;
 import com.vip.interviewpartner.dto.RoomCreateResponse;
+import com.vip.interviewpartner.dto.RoomResponseDTO;
 import com.vip.interviewpartner.service.RoomCreateService;
+import com.vip.interviewpartner.service.RoomLookupService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,9 +35,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/rooms")
+@Slf4j
 public class RoomController {
 
     private final RoomCreateService roomCreateService;
+    private final RoomLookupService roomLookupService;
 
     @Operation(summary = "방 생성 API",
             description = "새로운 모의면접방을 생성합니다.",
@@ -41,6 +55,24 @@ public class RoomController {
     public ApiCommonResponse<RoomCreateResponse> createRoom(@AuthenticationPrincipal CustomUserDetails customUserDetails, @Valid @RequestBody RoomCreateRequest roomCreateRequest) {
         RoomCreateResponse roomCreateResponse = roomCreateService.create(customUserDetails.getMemberId(), roomCreateRequest);
         return ApiCommonResponse.successResponse(roomCreateResponse);
+    }
+
+    @Operation(summary = "방 목록 조회 API",
+            description = "모의면접방을 목록을 조회합니다. 최신순으로 정렬됩니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "방 목록 조회 성공"),
+                    @ApiResponse(responseCode = "400", description = "요청 형식에 맞지 않음", content = @Content),
+                    @ApiResponse(responseCode = "500", description = "서버에러", content = @Content),
+            }
+    )
+    @SecurityRequirements(value = {})
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public ApiCommonResponse<List<RoomResponseDTO>> createRoom(@Parameter(description = "조회할 방의 상태(open OR closed)", required = true) @RequestParam(defaultValue = "open") String status,
+                                                               @Parameter(description = "페이지 정보. 기본값: size=6, sort=createDate, direction=DESC") @PageableDefault(size = 6, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        RoomStatus roomStatus = RoomStatus.fromString(status);
+        List<RoomResponseDTO> rooms = roomLookupService.getRoomsByStatus(roomStatus, pageable);
+        return ApiCommonResponse.successResponse(rooms);
     }
 
 }

--- a/server/src/main/java/com/vip/interviewpartner/domain/RoomStatus.java
+++ b/server/src/main/java/com/vip/interviewpartner/domain/RoomStatus.java
@@ -1,5 +1,8 @@
 package com.vip.interviewpartner.domain;
 
+import com.vip.interviewpartner.common.exception.CustomException;
+import com.vip.interviewpartner.common.exception.ErrorCode;
+
 /**
  * 방의 상태를 정의하는 열거형입니다.
  * OPEN: 방이 열려 있으며 사용자가 입장할 수 있는 상태입니다.
@@ -8,5 +11,13 @@ package com.vip.interviewpartner.domain;
  * 각 상태는 방의 생명주기를 관리하는 데 사용됩니다.
  */
 public enum RoomStatus {
-    OPEN, CLOSED, IN_PROGRESS
+    OPEN, CLOSED, IN_PROGRESS;
+
+    public static RoomStatus fromString(String status) {
+        try {
+            return RoomStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+    }
 }

--- a/server/src/main/java/com/vip/interviewpartner/dto/RoomResponseDTO.java
+++ b/server/src/main/java/com/vip/interviewpartner/dto/RoomResponseDTO.java
@@ -1,0 +1,53 @@
+package com.vip.interviewpartner.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.vip.interviewpartner.domain.Room;
+import com.vip.interviewpartner.domain.RoomStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 방 생성 응답 DTO 입니다.
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+public class RoomResponseDTO {
+    @Schema(description = "방 ID", example = "1")
+    private Long id;
+    @Schema(description = "방 제목", example = "Java 면접 연습")
+    private String title;
+    @Schema(description = "방의 세부 설명", example = "이 방은 Java 면접 질문 연습을 위한 방입니다.")
+    private String details;
+    @Schema(description = "방의 최대 참가자 수", example = "4")
+    private Integer maxParticipants;
+    @Schema(description = "방의 현재 참가자 수", example = "3")
+    private int currentParticipants;
+    @Schema(description = "방에 연결된 태그 목록", example = "[\"Java\", \"면접\", \"연습\"]")
+    private List<String> tags;
+    @Schema(description = "방의 현재 상태", example = "OPEN")
+    private RoomStatus roomStatus;
+
+    @Schema(description = "방 생성 시간", example = "2024.05.24 14:30")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm", timezone = "Asia/Seoul")
+    private LocalDateTime createdTime;
+
+    public static RoomResponseDTO of(Room room, int currentParticipants) {
+        return RoomResponseDTO.builder()
+                .id(room.getId())
+                .title(room.getTitle())
+                .details(room.getDetails())
+                .maxParticipants(room.getMaxParticipants())
+                .currentParticipants(currentParticipants)
+                .tags(room.getRoomTags().stream()
+                        .map(roomTag -> roomTag.getTag().getName())
+                        .toList())
+                .roomStatus(room.getStatus())
+                .createdTime(room.getCreateDate())
+                .build();
+    }
+}

--- a/server/src/main/java/com/vip/interviewpartner/repository/RoomRepository.java
+++ b/server/src/main/java/com/vip/interviewpartner/repository/RoomRepository.java
@@ -1,10 +1,22 @@
 package com.vip.interviewpartner.repository;
 
 import com.vip.interviewpartner.domain.Room;
+import com.vip.interviewpartner.domain.RoomStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 /**
  * Room 엔티티에 대한 데이터 접근 리포지토리입니다.
  */
 public interface RoomRepository extends JpaRepository<Room, Long> {
+    /**
+     * 주어진 상태의 방 목록을 페이징 처리하여 반환합니다.
+     * @param status 조회할 방의 상태
+     * @param pageable 페이징 정보
+     * @return 주어진 상태의 방 목록
+     */
+    @EntityGraph(attributePaths = {"roomTags", "roomTags.tag"})
+    Page<Room> findByStatus(RoomStatus status, Pageable pageable);
 }

--- a/server/src/main/java/com/vip/interviewpartner/service/OpenViduService.java
+++ b/server/src/main/java/com/vip/interviewpartner/service/OpenViduService.java
@@ -32,7 +32,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
- * OpenVidu 서비스를 처리하는 서비스 클래스.
+ * OpenVidu 서비스를 처리하는 서비스 클래스입니다.
  * OpenVidu 서버와의 통신을 담당합니다.
  */
 @Service
@@ -55,13 +55,36 @@ public class OpenViduService {
      * 새로운 세션을 생성합니다.
      *
      * @return 생성된 세션의 세션 ID
-     * @throws CustomException 서버 오류가 발생한 경우
+     * @throws CustomException Openvidu 서버가 응답하지 않는 경우
      */
     public String createSession() {
         try {
             SessionProperties properties = SessionProperties.fromJson(null).build();
             Session session = openVidu.createSession(properties);
             return session.getSessionId();
+        } catch (OpenViduJavaClientException e) {
+            throw new CustomException(SERVER_ERROR);
+        } catch (OpenViduHttpException e) {
+            throw new CustomException(SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 특정 세션의 연결 수를 반환합니다.
+     *
+     * @param sessionId 조회할 세션의 ID
+     * @return 세션에 연결된 연결 수
+     * @throws CustomException Openvidu 서버가 응답하지 않는 경우
+     */
+    public int getSessionConnectionCount(String sessionId) {
+        Session session = openVidu.getActiveSession(sessionId);
+        try {
+            if (session != null) {
+                session.fetch();
+                return session.getConnections().size();
+            } else {
+                return 0;
+            }
         } catch (OpenViduJavaClientException e) {
             throw new CustomException(SERVER_ERROR);
         } catch (OpenViduHttpException e) {

--- a/server/src/main/java/com/vip/interviewpartner/service/RoomLookupService.java
+++ b/server/src/main/java/com/vip/interviewpartner/service/RoomLookupService.java
@@ -1,0 +1,43 @@
+package com.vip.interviewpartner.service;
+
+import com.vip.interviewpartner.domain.Room;
+import com.vip.interviewpartner.domain.RoomStatus;
+import com.vip.interviewpartner.dto.RoomResponseDTO;
+import com.vip.interviewpartner.repository.RoomRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * RoomLookupService는 방의 상태에 따라 방 목록을 조회하는 서비스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RoomLookupService {
+
+    private final OpenViduService openViduService;
+    private final RoomRepository roomRepository;
+
+    /**
+     * 주어진 상태의 방 목록을 조회합니다.
+     *
+     * @param roomStatus 조회할 방의 상태
+     * @param pageable 페이징 정보
+     * @return 주어진 상태의 방 목록
+     */
+    public List<RoomResponseDTO> getRoomsByStatus(RoomStatus roomStatus, Pageable pageable) {
+        Page<Room> rooms = roomRepository.findByStatus(roomStatus, pageable);
+        if (roomStatus == RoomStatus.OPEN) {
+            return rooms.stream()
+                    .map(room -> RoomResponseDTO.of(room, openViduService.getSessionConnectionCount(room.getSessionId())))
+                    .toList();
+        }
+        return rooms.stream()
+                .map(room -> RoomResponseDTO.of(room, 0))
+                .toList();
+    }
+}


### PR DESCRIPTION
## Overview
- 모의면접 방 목록 조회 API를 작성하였습니다.
- 현재 참가자 수는 OpenVidu서비스에서 해당 방의 세션Id의 활성화된 연결 수를 받아서 처리하였습니다.
- `@EntityGraph` 어노테이션을 사용해서 N+1 문제를 해결해 기존의 태그에 관한 많은 쿼리를 패치조인으로 처리해 쿼리 성능을 향상시켰습니다.

## Change Log
- RoomController 수정
- RoomLookupService 추가
- OpenviduService 수정
- RoomResponseDTO 추가

## To Reviewer
- 당장은 RoomStatus 에서 OPEN, CLOSED 두개만 사용할 것  같습니다!

## Issue Tags
- Closed: #53 
