### PR TITLE
feat: 모의면접 방 채팅 저장 기능 구현

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -63,7 +63,7 @@ services:
       OPENVIDU_WEBHOOK: true
       OPENVIDU_WEBHOOK_ENDPOINT: http://server-container:8080/webhook
       OPENVIDU_WEBHOOK_HEADERS: '["Authorization: Basic cm9vdDpyb290MTIzNA=="]'
-      OPENVIDU_WEBHOOK_EVENTS: '["sessionDestroyed","participantJoined", "participantLeft"]'
+      OPENVIDU_WEBHOOK_EVENTS: '["sessionDestroyed","participantJoined", "participantLeft", "signalSent"]'
     networks:
       - network
 

--- a/server/src/main/java/com/vip/interviewpartner/common/constants/Constants.java
+++ b/server/src/main/java/com/vip/interviewpartner/common/constants/Constants.java
@@ -18,9 +18,18 @@ public final class Constants {
     public static final String BEARER_TOKEN_PREFIX = "Bearer ";
     public static final int COOKIE_REFRESH_EXPIRATION_SECONDS = 14 * 24 * 60 * 60; // 2주
 
+    //social login 관련
     public static final String NAVER = "naver";
     public static final String KAKAO = "kakao";
     public static final String GOOGLE = "google";
     public static final String ID_TOKEN = "idToken";
+
+    //Openvidu 관련
+    public static final String EVENT = "event";
+    public static final String SESSION_ID = "sessionId";
+    public static final String SERVER_DATA = "serverData";
+    public static final String DATA = "data";
+    public static final String CHAT = "chat";
+    public static final String TYPE = "type";
 
 }

--- a/server/src/main/java/com/vip/interviewpartner/common/constants/WebhookEvent.java
+++ b/server/src/main/java/com/vip/interviewpartner/common/constants/WebhookEvent.java
@@ -2,6 +2,10 @@ package com.vip.interviewpartner.common.constants;
 
 import java.util.Arrays;
 
+/**
+ * WebhookEvent 열거형은 웹훅 이벤트의 다양한 유형을 나타냅니다.
+ * 각 열거형 상수는 이벤트 타입을 식별하는 문자열 값을 포함합니다.
+ */
 public enum WebhookEvent {
     SESSION_DESTROYED("sessionDestroyed"),
     PARTICIPANT_JOINED("participantJoined"),
@@ -19,6 +23,13 @@ public enum WebhookEvent {
         return eventType;
     }
 
+    /**
+     * 주어진 이벤트 타입 문자열에 해당하는 WebhookEvent 열거형 상수를 반환합니다.
+     * 일치하는 이벤트 타입이 없으면 EMPTY 상수를 반환합니다.
+     *
+     * @param eventType 이벤트 타입을 나타내는 문자열
+     * @return 주어진 이벤트 타입에 해당하는 WebhookEvent 열거형 상수
+     */
     public static WebhookEvent findByEventType(String eventType) {
         return Arrays.stream(WebhookEvent.values())
                 .filter(event -> event.getEventType().equals(eventType))

--- a/server/src/main/java/com/vip/interviewpartner/common/constants/WebhookEvent.java
+++ b/server/src/main/java/com/vip/interviewpartner/common/constants/WebhookEvent.java
@@ -1,0 +1,28 @@
+package com.vip.interviewpartner.common.constants;
+
+import java.util.Arrays;
+
+public enum WebhookEvent {
+    SESSION_DESTROYED("sessionDestroyed"),
+    PARTICIPANT_JOINED("participantJoined"),
+    PARTICIPANT_LEFT("participantLeft"),
+    SIGNAL_SENT("signalSent"),
+    EMPTY("없음");
+
+    private final String eventType;
+
+    WebhookEvent(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public static WebhookEvent findByEventType(String eventType) {
+        return Arrays.stream(WebhookEvent.values())
+                .filter(event -> event.getEventType().equals(eventType))
+                .findFirst()
+                .orElse(EMPTY);
+    }
+}

--- a/server/src/main/java/com/vip/interviewpartner/common/exception/ErrorCode.java
+++ b/server/src/main/java/com/vip/interviewpartner/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     AUTHENTICATION_REQUIRED(401, "인증이 필요합니다."),
     FORBIDDEN(403, "권한이 없습니다."),
     SERVER_ERROR(500, "서버에 에러가 발생하였습니다."),
+    OPENVIDU_SERVER_ERROR(500, "OpenVidu 서버에 에러가 발생하였습니다."),
     DUPLICATE_EMAIL(409, "Email is already in use."),
     DUPLICATE_NICKNAME(409, "Nickname is already in use."),
     LOGIN_FAILURE(401, "로그인에 실패했습니다."),

--- a/server/src/main/java/com/vip/interviewpartner/common/util/DateTimeUtil.java
+++ b/server/src/main/java/com/vip/interviewpartner/common/util/DateTimeUtil.java
@@ -1,0 +1,24 @@
+package com.vip.interviewpartner.common.util;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Map;
+public class DateTimeUtil {
+
+    private static final String TIMESTAMP = "timestamp";
+    private static final String TIME_ZONE = "Asia/Seoul";
+
+    /**
+     * payload 에서 타임스탬프를 추출하고 LocalDateTime 객체로 변환합니다.
+     *
+     * @param payload 웹훅 이벤트의 페이로드
+     * @return 타임스탬프를 기반으로 생성된 LocalDateTime 객체
+     */
+    public static LocalDateTime extractTimestamp(Map<String, Object> payload) {
+        Long timestamp = (Long) payload.get(TIMESTAMP);
+        return Instant.ofEpochMilli(timestamp)
+                .atZone(ZoneId.of(TIME_ZONE))
+                .toLocalDateTime();
+    }
+}

--- a/server/src/main/java/com/vip/interviewpartner/domain/Message.java
+++ b/server/src/main/java/com/vip/interviewpartner/domain/Message.java
@@ -7,7 +7,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Message extends BaseCreateDateEntity {
+public class Message {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
@@ -32,4 +34,14 @@ public class Message extends BaseCreateDateEntity {
     private Member sender;
 
     private String content;
+
+    private LocalDateTime createDate;
+
+    @Builder
+    public Message(Room room, Member sender, String content, LocalDateTime createDate) {
+        this.room = room;
+        this.sender = sender;
+        this.content = content;
+        this.createDate = createDate;
+    }
 }

--- a/server/src/main/java/com/vip/interviewpartner/dto/RoomChatDTO.java
+++ b/server/src/main/java/com/vip/interviewpartner/dto/RoomChatDTO.java
@@ -1,0 +1,36 @@
+package com.vip.interviewpartner.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vip.interviewpartner.common.exception.CustomException;
+import com.vip.interviewpartner.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@Slf4j
+@ToString
+public class RoomChatDTO {
+    private Long memberId;
+    private Long roomId;
+    private String content;
+
+    /**
+     * JSON 문자열을 RoomChatDTO 객체로 변환합니다.
+     *
+     * @param json JSON 문자열
+     * @return RoomChatDTO 객체
+     * @throws CustomException JSON 문자열을 객체로 변환하는 데 실패한 경우 발생
+     */
+    public static RoomChatDTO fromJson(String json) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        try {
+            return objectMapper.readValue(json, RoomChatDTO.class);
+        } catch (JsonProcessingException e) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+}

--- a/server/src/main/java/com/vip/interviewpartner/dto/RoomChatDTO.java
+++ b/server/src/main/java/com/vip/interviewpartner/dto/RoomChatDTO.java
@@ -9,6 +9,9 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * RoomChatDTO 클래스는 채팅 메시지의 데이터 전송 객체입니다.
+ */
 @Getter
 @Slf4j
 @ToString
@@ -19,6 +22,7 @@ public class RoomChatDTO {
 
     /**
      * JSON 문자열을 RoomChatDTO 객체로 변환합니다.
+     * Deserialization 중에 알 수 없는 속성은 무시합니다.
      *
      * @param json JSON 문자열
      * @return RoomChatDTO 객체

--- a/server/src/main/java/com/vip/interviewpartner/dto/RoomChatDTO.java
+++ b/server/src/main/java/com/vip/interviewpartner/dto/RoomChatDTO.java
@@ -1,7 +1,6 @@
 package com.vip.interviewpartner.dto;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vip.interviewpartner.common.exception.CustomException;
 import com.vip.interviewpartner.common.exception.ErrorCode;
@@ -19,10 +18,10 @@ public class RoomChatDTO {
     private Long memberId;
     private Long roomId;
     private String content;
+    private String nickname;
 
     /**
      * JSON 문자열을 RoomChatDTO 객체로 변환합니다.
-     * Deserialization 중에 알 수 없는 속성은 무시합니다.
      *
      * @param json JSON 문자열
      * @return RoomChatDTO 객체
@@ -30,7 +29,6 @@ public class RoomChatDTO {
      */
     public static RoomChatDTO fromJson(String json) {
         ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         try {
             return objectMapper.readValue(json, RoomChatDTO.class);
         } catch (JsonProcessingException e) {

--- a/server/src/main/java/com/vip/interviewpartner/service/OpenViduService.java
+++ b/server/src/main/java/com/vip/interviewpartner/service/OpenViduService.java
@@ -18,8 +18,8 @@
 
 package com.vip.interviewpartner.service;
 
+import static com.vip.interviewpartner.common.exception.ErrorCode.OPENVIDU_SERVER_ERROR;
 import static com.vip.interviewpartner.common.exception.ErrorCode.ROOM_CLOSED;
-import static com.vip.interviewpartner.common.exception.ErrorCode.SERVER_ERROR;
 
 import com.vip.interviewpartner.common.exception.CustomException;
 import io.openvidu.java.client.Connection;
@@ -123,6 +123,6 @@ public class OpenViduService {
      */
     private CustomException handleOpenViduException(Exception e) {
         log.error("OpenVidu error: {}", e.getMessage(), e);
-        return new CustomException(SERVER_ERROR);
+        return new CustomException(OPENVIDU_SERVER_ERROR);
     }
 }


### PR DESCRIPTION
## Overview
- 모의면접 방에서 발생한 채팅들을 데이터베이스에 저장하는 기능을 추가하였습니다.
- 기존 웹훅 이벤트에 채팅이 발생하는 이벤트를 추가하였습니다.

## Change Log
- WebhookService 수정
- docker-compose.dev.yml 수정
- WebhookEvent Enum 추가
- DateTimeUtil 추가
- RoomChatDTO 추가

## To Reviewer
- 프론트에서 알 수 있도록 Openvidu 서버에러와 백엔드 서버에러 코드를 구분지었습니다.

## Issue Tags
- Closed: #75
