### PR TITLE
feat: 회원정보 수정 API 작성

### DIFF
--- a/server/src/main/java/com/vip/interviewpartner/controller/MemberController.java
+++ b/server/src/main/java/com/vip/interviewpartner/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.vip.interviewpartner.common.ApiCommonResponse;
 import com.vip.interviewpartner.dto.CustomUserDetails;
 import com.vip.interviewpartner.dto.MemberInfoResponse;
 import com.vip.interviewpartner.dto.MemberJoinRequest;
+import com.vip.interviewpartner.dto.MemberUpdateRequest;
 import com.vip.interviewpartner.dto.NicknameCheckResponse;
 import com.vip.interviewpartner.dto.ResumeLookupResponse;
 import com.vip.interviewpartner.service.MemberJoinService;
@@ -71,7 +72,7 @@ public class MemberController {
      * 닉네임이 사용 가능한 경우 true를, 그렇지 않을 경우 false를 담아서 반환합니다.
      *
      * @param nickname 확인할 닉네임
-     * @return ApiCommonResponse<NicknameCheckResponse> 닉네임 중복 확인 응답 객체;
+     * @return ApiCommonResponse<NicknameCheckResponse> 닉네임 중복 확인 응답 객체
      */
     @Operation(summary = "닉네임 중복 확인 API",
             description = "회원가입시 닉네임 중복 확인",
@@ -108,6 +109,28 @@ public class MemberController {
     public ApiCommonResponse<MemberInfoResponse> getMemberInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         MemberInfoResponse memberInfoResponse = memberService.getMemberInfo(customUserDetails.getMemberId());
         return ApiCommonResponse.successResponse(memberInfoResponse);
+    }
+
+    /**
+     * 현재 로그인된 사용자의 회원 정보를 수정하는 API입니다.
+     *
+     * @param customUserDetails 사용자 인증 정보
+     * @return ApiCommonResponse.successWithNoContent
+     */
+    @Operation(summary = "회원정보 수정 API",
+            description = "현재 로그인된 사용자의 회원 정보를 수정합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "회원정보 조회 성공"),
+                    @ApiResponse(responseCode = "400", description = "유효한 요청이 아님", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+            }
+    )
+    @PutMapping("/me")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiCommonResponse<?> updateMemberInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                 @Valid @RequestBody MemberUpdateRequest request) {
+        memberService.updateInfo(customUserDetails.getMemberId(), request);
+        return ApiCommonResponse.successWithNoContent();
     }
 
     /**

--- a/server/src/main/java/com/vip/interviewpartner/controller/MemberController.java
+++ b/server/src/main/java/com/vip/interviewpartner/controller/MemberController.java
@@ -126,7 +126,7 @@ public class MemberController {
                     @ApiResponse(responseCode = "409", description = "닉네임 중복", content = @Content),
             }
     )
-    @PutMapping("/me")
+    @PatchMapping("/me")
     @ResponseStatus(HttpStatus.OK)
     public ApiCommonResponse<?> updateMemberInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails,
                                                  @Valid @RequestBody MemberUpdateRequest request) {

--- a/server/src/main/java/com/vip/interviewpartner/controller/MemberController.java
+++ b/server/src/main/java/com/vip/interviewpartner/controller/MemberController.java
@@ -123,6 +123,7 @@ public class MemberController {
                     @ApiResponse(responseCode = "200", description = "회원정보 조회 성공"),
                     @ApiResponse(responseCode = "400", description = "유효한 요청이 아님", content = @Content),
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "409", description = "닉네임 중복", content = @Content),
             }
     )
     @PutMapping("/me")

--- a/server/src/main/java/com/vip/interviewpartner/domain/Member.java
+++ b/server/src/main/java/com/vip/interviewpartner/domain/Member.java
@@ -1,5 +1,6 @@
 package com.vip.interviewpartner.domain;
 
+import com.vip.interviewpartner.dto.MemberUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -65,5 +66,9 @@ public class Member extends BaseTimeEntity {
         this.providerId = providerId;
         this.isActive = true;
         this.role = Role.ROLE_USER;
+    }
+
+    public void updateInfo(MemberUpdateRequest request) {
+        this.nickname = request.getNickname();
     }
 }

--- a/server/src/main/java/com/vip/interviewpartner/dto/MemberUpdateRequest.java
+++ b/server/src/main/java/com/vip/interviewpartner/dto/MemberUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.vip.interviewpartner.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "회원가입 수정 DTO")
+public class MemberUpdateRequest {
+    @Schema(description = "닉네임", example = "nickname12")
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(min = 2, max = 10, message = "닉네임은 2자 이상, 10자 이하여야 합니다.")
+    private String nickname;
+}

--- a/server/src/main/java/com/vip/interviewpartner/service/MemberJoinService.java
+++ b/server/src/main/java/com/vip/interviewpartner/service/MemberJoinService.java
@@ -1,9 +1,8 @@
 package com.vip.interviewpartner.service;
 
-import static com.vip.interviewpartner.common.exception.ErrorCode.*;
+import static com.vip.interviewpartner.common.exception.ErrorCode.DUPLICATE_EMAIL;
 
 import com.vip.interviewpartner.common.exception.CustomException;
-import com.vip.interviewpartner.common.exception.ErrorCode;
 import com.vip.interviewpartner.domain.Member;
 import com.vip.interviewpartner.dto.MemberJoinRequest;
 import com.vip.interviewpartner.repository.MemberRepository;
@@ -21,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberJoinService {
 
+    private final MemberService memberService;
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
@@ -34,15 +34,14 @@ public class MemberJoinService {
     @Transactional
     public void join(MemberJoinRequest memberJoinRequest) {
         checkEmailDuplication(memberJoinRequest.getEmail());
-        checkNicknameDuplication(memberJoinRequest.getNickname());
+        memberService.checkNicknameDuplication(memberJoinRequest.getNickname());
         String encodePassword = bCryptPasswordEncoder.encode(memberJoinRequest.getPassword());
         Member member = memberJoinRequest.toEntity(encodePassword);
         memberRepository.save(member);
     }
 
     /**
-     * 주어진 닉네임의 사용 가능 여부를 확인하는 메서드입니다.
-     * 닉네임이 사용 중인지 아닌지를 판단합니다.
+     * 주어진 닉네임의 사용 가능 여부를 확인하는 메서드입니다. 닉네임이 사용 중인지 아닌지를 판단합니다.
      *
      * @param nickname 검사하고자 하는 사용자의 닉네임
      * @return 닉네임이 사용 가능할 경우 true, 그렇지 않을 경우 false를 반환합니다.
@@ -61,19 +60,6 @@ public class MemberJoinService {
     private void checkEmailDuplication(String email) {
         if (memberRepository.existsByEmail(email)) {
             throw new CustomException(DUPLICATE_EMAIL);
-        }
-    }
-
-    /**
-     * 입력된 닉네임이 이미 존재하는지 확인합니다.
-     * 이미 존재하는 경우 CustomException을 발생시킵니다.
-     *
-     * @param nickname 확인할 닉네임
-     * @throws CustomException 이미 존재하는 닉네임인 경우 발생하는 예외
-     */
-    private void checkNicknameDuplication(String nickname) {
-        if (memberRepository.existsByNickname(nickname)) {
-            throw new CustomException(DUPLICATE_NICKNAME);
         }
     }
 }

--- a/server/src/main/java/com/vip/interviewpartner/service/MemberService.java
+++ b/server/src/main/java/com/vip/interviewpartner/service/MemberService.java
@@ -1,9 +1,12 @@
 package com.vip.interviewpartner.service;
 
+import static com.vip.interviewpartner.common.exception.ErrorCode.DUPLICATE_NICKNAME;
+
 import com.vip.interviewpartner.common.exception.CustomException;
 import com.vip.interviewpartner.common.exception.ErrorCode;
 import com.vip.interviewpartner.domain.Member;
 import com.vip.interviewpartner.dto.MemberInfoResponse;
+import com.vip.interviewpartner.dto.MemberUpdateRequest;
 import com.vip.interviewpartner.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,6 +36,19 @@ public class MemberService {
     }
 
     /**
+     * 입력된 닉네임이 이미 존재하는지 확인합니다.
+     * 이미 존재하는 경우 CustomException을 발생시킵니다.
+     *
+     * @param nickname 확인할 닉네임
+     * @throws CustomException 이미 존재하는 닉네임인 경우 발생하는 예외
+     */
+    public void checkNicknameDuplication(String nickname) {
+        if (memberRepository.existsByNickname(nickname)) {
+            throw new CustomException(DUPLICATE_NICKNAME);
+        }
+    }
+
+    /**
      * 주어진 ID로 회원 정보를 조회하여 MemberInfoResponse DTO로 반환합니다.
      * 내부적으로 getMemberById 메서드를 호출하여 Member 객체를 조회합니다.
      *
@@ -43,5 +59,20 @@ public class MemberService {
     public MemberInfoResponse getMemberInfo(Long memberId) {
         Member member = getMemberById(memberId);
         return MemberInfoResponse.of(member);
+    }
+
+    /**
+     * 주어진 ID의 회원 정보를 업데이트합니다.
+     * 닉네임의 중복 여부를 확인하고, 중복되지 않으면 회원 정보를 업데이트합니다.
+     *
+     * @param memberId 업데이트할 회원의 ID
+     * @param request 업데이트할 정보를 담고 있는 MemberUpdateRequest 객체
+     * @throws CustomException 닉네임이 중복되는 경우 발생하는 예외
+     */
+    @Transactional
+    public void updateInfo(Long memberId, MemberUpdateRequest request) {
+        checkNicknameDuplication(request.getNickname());
+        Member member = getMemberById(memberId);
+        member.updateInfo(request);
     }
 }

--- a/server/src/test/java/com/vip/interviewpartner/service/MemberJoinServiceTest.java
+++ b/server/src/test/java/com/vip/interviewpartner/service/MemberJoinServiceTest.java
@@ -20,12 +20,14 @@ class MemberJoinServiceTest {
     private MemberRepository memberRepository;
     private BCryptPasswordEncoder bCryptPasswordEncoder;
     private MemberJoinService memberJoinService;
+    private MemberService memberService;
 
     @BeforeEach
     void setUp() {
         memberRepository = Mockito.mock(MemberRepository.class);
         bCryptPasswordEncoder = Mockito.mock(BCryptPasswordEncoder.class);
-        memberJoinService = new MemberJoinService(memberRepository, bCryptPasswordEncoder);
+        memberService = new MemberService(memberRepository);
+        memberJoinService = new MemberJoinService(memberService, memberRepository, bCryptPasswordEncoder);
     }
 
     @Test
@@ -61,13 +63,12 @@ class MemberJoinServiceTest {
     void checkNicknameDuplication() {
         // given
         MemberJoinRequest member1 = new MemberJoinRequest("asd@naver.com", "12345678", "홍길동");
-        MemberJoinRequest member2 = new MemberJoinRequest("asdasd@naver.com", "12345678", "홍길동");
 
         when(memberRepository.existsByEmail(member1.getEmail())).thenReturn(false);
         when(memberRepository.existsByNickname(member1.getNickname())).thenReturn(true);
 
         // then
-        assertThatThrownBy(() -> memberJoinService.join(member2))
+        assertThatThrownBy(() -> memberJoinService.join(member1))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(DUPLICATE_NICKNAME);


### PR DESCRIPTION
## Overview
- 회원정보 수정하는 API를 작성하였습니다.
- 현재 수정 가능한 필드는 닉네임뿐이며, 비밀번호는 따로 API를 만드는게 보안 상 좋다고 생각하여 분리하였습니다.

## Change Log
- MemberController 수정
- MemberService 수정
- MemberUpdateRequest 추가

## To Reviewer
- 회원정보 수정 API는 변경 가능한 일부 필드만을 수정하므로 PUT method가 아닌 PATCH method를 사용하였습니다.

## Issue Tags
- Closed: #83 
