### PR TITLE
feat: AI 면접 질문 조회 API 작성

### DIFF
--- a/server/src/main/java/com/vip/interviewpartner/common/exception/ErrorCode.java
+++ b/server/src/main/java/com/vip/interviewpartner/common/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     INVALID_TOKEN(401, "유효하지 않는 토큰입니다."),
     REFRESH_TOKEN_NOT_EXIST(401, "리프레쉬 토큰이 존재하지 않습니다."),
     FORBIDDEN(403, "권한이 없습니다."),
+    MEMBER_ID_MISMATCH(403, "요청자와 인터뷰의 소유자가 일치하지 않습니다."),
     RESOURCE_NOT_FOUND(404, "요청한 리소스가 존재하지 않습니다."),
     DUPLICATE_EMAIL(409, "Email is already in use."),
     DUPLICATE_NICKNAME(409, "Nickname is already in use."),

--- a/server/src/main/java/com/vip/interviewpartner/controller/InterviewController.java
+++ b/server/src/main/java/com/vip/interviewpartner/controller/InterviewController.java
@@ -69,14 +69,14 @@ public class InterviewController {
             responses = {
                     @ApiResponse(responseCode = "200", description = "질문 조회 성공"),
                     @ApiResponse(responseCode = "400", description = "질문이 존재하지 않습니다", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "요청자와 인터뷰의 소유자가 일치하지 않습니다", content = @Content),
             }
     )
 
-    @SecurityRequirements(value = {})
     @GetMapping("/{interviewId}/questions")
     @ResponseStatus(HttpStatus.OK)
-    public ApiCommonResponse<List<QuestionLookupResponse>> getQuestions(@NotNull(message = "인터뷰 아이디는 필수입니다.") @PathVariable Long interviewId) {
-        List<QuestionLookupResponse> questions = questionFinderService.getQuestionsByInterviewId(interviewId);
+    public ApiCommonResponse<List<QuestionLookupResponse>> getQuestions(@AuthenticationPrincipal CustomUserDetails customUserDetails, @NotNull(message = "인터뷰 아이디는 필수입니다.") @PathVariable Long interviewId) {
+        List<QuestionLookupResponse> questions = questionFinderService.getQuestionsByInterviewId(customUserDetails, interviewId);
         return ApiCommonResponse.successResponse(questions);
     }
 

--- a/server/src/main/java/com/vip/interviewpartner/controller/InterviewController.java
+++ b/server/src/main/java/com/vip/interviewpartner/controller/InterviewController.java
@@ -3,22 +3,24 @@ package com.vip.interviewpartner.controller;
 import com.vip.interviewpartner.common.ApiCommonResponse;
 import com.vip.interviewpartner.dto.AiInterviewRequest;
 import com.vip.interviewpartner.dto.CustomUserDetails;
+import com.vip.interviewpartner.dto.QuestionLookupResponse;
 import com.vip.interviewpartner.service.AiInterviewCreateService;
+import com.vip.interviewpartner.service.QuestionFinderService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * 인터뷰 컨트롤러 입니다. 이 컨트롤러는 인터뷰 관련 API를 처리합니다.
@@ -30,8 +32,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @Validated
 public class InterviewController {
-
     private final AiInterviewCreateService aiInterviewCreateService;
+    private final QuestionFinderService questionFinderService;
 
     /**
      * 인터뷰 생성 매서드입니다.
@@ -53,6 +55,29 @@ public class InterviewController {
 
         Long InterviewId = aiInterviewCreateService.create(customUserDetails.getMemberId(), aiInterviewRequest);
         return ApiCommonResponse.successResponse(InterviewId);
+    }
+
+
+    /**
+     * 질문 조회 API 입니다.
+     *
+     * @param interviewId 질문을 조회하고자 하는 인터뷰의 아이디 입니다.
+     * @return ApiCommonResponse<List<QuestionLookupResponse>> 조회된 질문 리스트 응답 객체
+     */
+    @Operation(summary = "이력서 조회 API",
+            description = "현재 인터뷰 방의 질문들을 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "질문 조회 성공"),
+                    @ApiResponse(responseCode = "400", description = "질문이 존재하지 않습니다", content = @Content),
+            }
+    )
+
+    @SecurityRequirements(value = {})
+    @GetMapping("/{interviewId}/questions")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiCommonResponse<List<QuestionLookupResponse>> getQuestions(@NotNull(message = "인터뷰 아이디는 필수입니다.") @PathVariable Long interviewId) {
+        List<QuestionLookupResponse> questions = questionFinderService.getQuestionsByInterviewId(interviewId);
+        return ApiCommonResponse.successResponse(questions);
     }
 
 }

--- a/server/src/main/java/com/vip/interviewpartner/dto/QuestionLookupResponse.java
+++ b/server/src/main/java/com/vip/interviewpartner/dto/QuestionLookupResponse.java
@@ -1,0 +1,38 @@
+package com.vip.interviewpartner.dto;
+
+import com.vip.interviewpartner.domain.Question;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 질문 조회 응답 DTO 클래스입니다.
+ * 이 클래스는 질문 조회 API의 응답 데이터를 담고 있습니다.
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Schema(description = "질문 조회 응답 DTO")
+public class QuestionLookupResponse {
+    @Schema(description = "질문 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "질문 내용", example = "해당 프로젝트에서 Lambda를 사용한 이유는 무엇인가요?")
+    private String content;
+
+    /**
+     * Question Entity -> QuestionLookupResponse DTO 변환하는 메서드입니다.
+     *
+     * @param question 변환할 Question 엔티티
+     * @return 변환된 QuestionLookupResponse 객체
+     */
+    public static QuestionLookupResponse of(Question question) {
+        return QuestionLookupResponse.builder()
+                .id(question.getId())
+                .content(question.getContent())
+                .build();
+    }
+}

--- a/server/src/main/java/com/vip/interviewpartner/repository/InterviewRepository.java
+++ b/server/src/main/java/com/vip/interviewpartner/repository/InterviewRepository.java
@@ -1,10 +1,22 @@
 package com.vip.interviewpartner.repository;
 
 import com.vip.interviewpartner.domain.Interview;
+import com.vip.interviewpartner.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 /**
  * Interview 엔티티에 대한 데이터 접근 리포지토리입니다.
  */
 public interface InterviewRepository extends JpaRepository<Interview, Long> {
+    /**
+     * 인터뷰 ID가 주어지면 인터뷰의 멤버 객체를 반환하는 매서드입니다.
+     *
+     * @param id 인터뷰 ID
+     * @return 인터뷰의 멤버 객체
+     */
+    @Query("SELECT i.member FROM Interview i WHERE i.id = :id")
+    Optional<Member> findMemberById(Long id);
 }

--- a/server/src/main/java/com/vip/interviewpartner/repository/QuestionRepository.java
+++ b/server/src/main/java/com/vip/interviewpartner/repository/QuestionRepository.java
@@ -3,8 +3,11 @@ package com.vip.interviewpartner.repository;
 import com.vip.interviewpartner.domain.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 /**
  * Question 엔티티에 대한 데이터 접근 리포지토리입니다.
  */
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+    List<Question> findByInterviewId(Long interviewId);
 }

--- a/server/src/main/java/com/vip/interviewpartner/service/QuestionFinderService.java
+++ b/server/src/main/java/com/vip/interviewpartner/service/QuestionFinderService.java
@@ -2,8 +2,11 @@ package com.vip.interviewpartner.service;
 
 import com.vip.interviewpartner.common.exception.CustomException;
 import com.vip.interviewpartner.common.exception.ErrorCode;
+import com.vip.interviewpartner.domain.Member;
 import com.vip.interviewpartner.domain.Question;
+import com.vip.interviewpartner.dto.CustomUserDetails;
 import com.vip.interviewpartner.dto.QuestionLookupResponse;
+import com.vip.interviewpartner.repository.InterviewRepository;
 import com.vip.interviewpartner.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,11 +14,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.vip.interviewpartner.common.exception.ErrorCode.INVALID_REQUEST;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class QuestionFinderService {
     private final QuestionRepository questionRepository;
+    private final InterviewRepository interviewRepository;
 
     /**
      * 주어진 인터뷰 ID에 해당하는 질문 목록들을 조회합니다.
@@ -23,7 +29,8 @@ public class QuestionFinderService {
      * @param interviewId 이력서를 조회할 회원의 ID
      * @return 주어진 인터뷰 ID에 해당하는 질문 목록을 담은 QuestionLookupResponse 리스트
      */
-    public List<QuestionLookupResponse> getQuestionsByInterviewId(Long interviewId) {
+    public List<QuestionLookupResponse> getQuestionsByInterviewId(CustomUserDetails customUserDetails, Long interviewId) {
+        validateSender(customUserDetails.getMemberId(), interviewId);
         List<Question> questions = questionRepository.findByInterviewId(interviewId);
         if (questions.isEmpty()) {
             throw new CustomException(ErrorCode.INVALID_REQUEST);
@@ -32,6 +39,20 @@ public class QuestionFinderService {
         return questions.stream()
                 .map(QuestionLookupResponse::of)
                 .toList();
+    }
+
+    /**
+     * 요청을 보낸 사용자가 인터뷰의 소유자와 일치하는지 검증합니다.
+     *
+     * @param memberId 요청을 보낸 사용자의 Id
+     * @param interviewId 인터뷰Id
+     */
+    private void validateSender(Long memberId, Long interviewId){
+        Member interviewMember = interviewRepository.findMemberById(interviewId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        if(!interviewMember.getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.MEMBER_ID_MISMATCH);
+        }
     }
 
 }

--- a/server/src/main/java/com/vip/interviewpartner/service/QuestionFinderService.java
+++ b/server/src/main/java/com/vip/interviewpartner/service/QuestionFinderService.java
@@ -1,0 +1,39 @@
+package com.vip.interviewpartner.service;
+
+import com.vip.interviewpartner.common.exception.CustomException;
+import com.vip.interviewpartner.common.exception.ErrorCode;
+import com.vip.interviewpartner.domain.Question;
+import com.vip.interviewpartner.dto.QuestionLookupResponse;
+import com.vip.interviewpartner.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuestionFinderService {
+    private final QuestionRepository questionRepository;
+
+    /**
+     * 주어진 인터뷰 ID에 해당하는 질문 목록들을 조회합니다.
+     *
+     * @param interviewId 이력서를 조회할 회원의 ID
+     * @return 주어진 인터뷰 ID에 해당하는 질문 목록을 담은 QuestionLookupResponse 리스트
+     */
+    public List<QuestionLookupResponse> getQuestionsByInterviewId(Long interviewId) {
+        List<Question> questions = questionRepository.findByInterviewId(interviewId);
+        if (questions.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        return questions.stream()
+                .map(QuestionLookupResponse::of)
+                .toList();
+    }
+
+}
+
+


### PR DESCRIPTION
## Overview
- AI 면접 질문 조회 API 작성했습니다.
- `interviewId` 를 쿼리스트링으로 받으면 `QuestionLookupResponse`를 담은 리스트를 반환합니다.

## Change Log
- InterviewController 수정
- QuestionLookupResponse 생성
- QuestionFinderService 생성
- QuestionRepository 변경

## To Reviewer
- InterviewController에서 쿼리스트링으로 `interviewId`를 받는데 이때 NotNull이 필요한지 확인해주세요.
- QuestionFinderService에서 questions가 비워져있을때 에러를 발생시키는데 이게 맞는지 확인해주세요.

## Issue Tags
- Closed: #84
