### PR TITLE
feat: 자신의 모의면접 방 참가 이력을 조회하는 API 작성

### DIFF
--- a/server/src/main/java/com/vip/interviewpartner/controller/MemberController.java
+++ b/server/src/main/java/com/vip/interviewpartner/controller/MemberController.java
@@ -199,7 +199,7 @@ public class MemberController {
     @GetMapping("/me/rooms/participations")
     @ResponseStatus(HttpStatus.OK)
     public ApiCommonResponse<PageCustom<ParticipationResponse>> getParticipation(@AuthenticationPrincipal CustomUserDetails customUserDetails,
-                                                                           @Parameter(description = "페이지 기본값: page=0, size=10, sort=createDate, direction=DESC") @PageableDefault(size = 10, sort = "joinDate", direction = Sort.Direction.DESC) Pageable pageable) {
+                                                                           @Parameter(description = "페이지 기본값: page=0, size=10, sort=joinDate, direction=DESC") @PageableDefault(size = 10, sort = "joinDate", direction = Sort.Direction.DESC) Pageable pageable) {
         PageCustom<ParticipationResponse> participationResponses = participantLookupService.getParticipation(customUserDetails.getMemberId(), pageable);
         return ApiCommonResponse.successResponse(participationResponses);
     }

--- a/server/src/main/java/com/vip/interviewpartner/controller/MemberController.java
+++ b/server/src/main/java/com/vip/interviewpartner/controller/MemberController.java
@@ -196,7 +196,7 @@ public class MemberController {
                     @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
             }
     )
-    @GetMapping("/me/rooms")
+    @GetMapping("/me/rooms/participations")
     @ResponseStatus(HttpStatus.OK)
     public ApiCommonResponse<PageCustom<ParticipationResponse>> getParticipation(@AuthenticationPrincipal CustomUserDetails customUserDetails,
                                                                            @Parameter(description = "페이지 기본값: page=0, size=10, sort=createDate, direction=DESC") @PageableDefault(size = 10, sort = "joinDate", direction = Sort.Direction.DESC) Pageable pageable) {

--- a/server/src/main/java/com/vip/interviewpartner/controller/MemberController.java
+++ b/server/src/main/java/com/vip/interviewpartner/controller/MemberController.java
@@ -6,12 +6,16 @@ import com.vip.interviewpartner.dto.MemberInfoResponse;
 import com.vip.interviewpartner.dto.MemberJoinRequest;
 import com.vip.interviewpartner.dto.MemberUpdateRequest;
 import com.vip.interviewpartner.dto.NicknameCheckResponse;
+import com.vip.interviewpartner.dto.PageCustom;
+import com.vip.interviewpartner.dto.ParticipationResponse;
 import com.vip.interviewpartner.dto.ResumeLookupResponse;
 import com.vip.interviewpartner.service.MemberJoinService;
 import com.vip.interviewpartner.service.MemberService;
+import com.vip.interviewpartner.service.ParticipantLookupService;
 import com.vip.interviewpartner.service.ResumeService;
 import com.vip.interviewpartner.service.ResumeUploadService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
@@ -22,6 +26,9 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -44,6 +51,7 @@ public class MemberController {
     private final MemberService memberService;
     private final ResumeUploadService resumeUploadService;
     private final ResumeService resumeService;
+    private final ParticipantLookupService participantLookupService;
 
     /**
      * 회원가입 API입니다.
@@ -174,6 +182,26 @@ public class MemberController {
     public ApiCommonResponse<List<ResumeLookupResponse>> getResumes(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         List<ResumeLookupResponse> resumes = resumeService.getResumesByMemberId(customUserDetails.getMemberId());
         return ApiCommonResponse.successResponse(resumes);
+    }
+
+    /**
+     * 현재 로그인된 사용자의 방 참가 이력을 조회하는 API입니다.
+     * @param customUserDetails 사용자 인증 정보
+     * @return ApiCommonResponse<PageCustom<ParticipationResponse>> 조회된 방 참가 이력 조회 응답 객체
+     */
+    @Operation(summary = "방 참가 이력 조회 API",
+            description = "현재 로그인된 사용자의 방 참가 이력을 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "이력서 조회 성공"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+            }
+    )
+    @GetMapping("/me/rooms")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiCommonResponse<PageCustom<ParticipationResponse>> getParticipation(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                                           @Parameter(description = "페이지 기본값: page=0, size=10, sort=createDate, direction=DESC") @PageableDefault(size = 10, sort = "joinDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        PageCustom<ParticipationResponse> participationResponses = participantLookupService.getParticipation(customUserDetails.getMemberId(), pageable);
+        return ApiCommonResponse.successResponse(participationResponses);
     }
 
 }

--- a/server/src/main/java/com/vip/interviewpartner/dto/FeedbackCountDTO.java
+++ b/server/src/main/java/com/vip/interviewpartner/dto/FeedbackCountDTO.java
@@ -1,0 +1,16 @@
+package com.vip.interviewpartner.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * FeedbackCountDTO 클래스는 피드백을 받은 참가자 ID와 받은 피드백 개수를 담는 DTO 입니다.
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FeedbackCountDTO {
+    private Long receiverId;
+    private Long count;
+}

--- a/server/src/main/java/com/vip/interviewpartner/dto/ParticipationResponse.java
+++ b/server/src/main/java/com/vip/interviewpartner/dto/ParticipationResponse.java
@@ -1,0 +1,53 @@
+package com.vip.interviewpartner.dto;
+
+import com.vip.interviewpartner.domain.RoomParticipant;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.format.DateTimeFormatter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 방 참가 이력 조회 응답 DTO 클래스입니다.
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Schema(description = "방 참가 이력 조회 응답 DTO")
+public class ParticipationResponse {
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+
+    @Schema(description = "참가 ID", example = "1")
+    private Long participantId;
+
+    @Schema(description = "방 ID", example = "1")
+    private Long roomId;
+
+    @Schema(description = "방 제목", example = "네카라쿠배 면접 대비 방")
+    private String roomTitle;
+
+    @Schema(description = "방 참가 날짜 및 시간", example = "2024.05.24 14:30")
+    private String joinDate;
+
+    @Schema(description = "피드백 개수 (해당 방에서 받은 피드백 개수)", example = "3")
+    private int feedbackCount;
+
+    /**
+     * RoomParticipant Entity -> ParticipationResponse DTO 변환하는 메서드입니다.
+     *
+     * @param participant RoomParticipant 객체
+     * @param feedbackCount 피드백 개수
+     * @return 생성된 ParticipationResponse 객체
+     */
+    public static ParticipationResponse of(RoomParticipant participant, int feedbackCount) {
+        return ParticipationResponse.builder()
+                .participantId(participant.getId())
+                .roomId(participant.getRoom().getId())
+                .roomTitle(participant.getRoom().getTitle())
+                .joinDate(participant.getJoinDate().format(formatter))
+                .feedbackCount(feedbackCount)
+                .build();
+    }
+}

--- a/server/src/main/java/com/vip/interviewpartner/repository/FeedbackRepository.java
+++ b/server/src/main/java/com/vip/interviewpartner/repository/FeedbackRepository.java
@@ -2,7 +2,11 @@ package com.vip.interviewpartner.repository;
 
 import com.vip.interviewpartner.domain.Feedback;
 import com.vip.interviewpartner.domain.RoomParticipant;
+import com.vip.interviewpartner.dto.FeedbackCountDTO;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Feedback 엔티티에 대한 데이터 접근 리포지토리입니다.
@@ -11,9 +15,20 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     /**
      * 주어진 보낸 사람과 받는 사람 간에 이미 존재하는 피드백이 있는지 확인합니다.
      *
-     * @param sender 피드백의 보낸 사람인 RoomParticipant 객체
-     * @param receiver 피드백의 받는 사람인 RoomParticipant 객체
+     * @param sender 피드백을 보낸 사람인 RoomParticipant 객체
+     * @param receiver 피드백을 받는 사람인 RoomParticipant 객체
      * @return 보낸 사람과 받는 사람 조합으로 이미 존재하는 피드백이 있으면 true, 없으면 false를 반환합니다.
      */
     boolean existsBySenderAndReceiver(RoomParticipant sender, RoomParticipant receiver);
+
+    /**
+     * 피드백을 받은 참가자 ID 목록에 대한 피드백 개수를 조회합니다.
+     * 피드백을 받은 참가자 ID 별로 피드백 개수를 그룹화하여 FeedbackCountDTO 객체로 반환합니다.
+     *
+     * @param receiverIds 피드백을 받은 참가자 ID 목록
+     * @return FeedbackCountDTO 객체 리스트
+     */
+    @Query("SELECT new com.vip.interviewpartner.dto.FeedbackCountDTO(f.receiver.id, COUNT(f))"
+            + "FROM Feedback f WHERE f.receiver.id IN :receiverIds GROUP BY f.receiver.id")
+    List<FeedbackCountDTO> countFeedbacksByReceiverIds(@Param("receiverIds") List<Long> receiverIds);
 }

--- a/server/src/main/java/com/vip/interviewpartner/repository/RoomParticipantRepository.java
+++ b/server/src/main/java/com/vip/interviewpartner/repository/RoomParticipantRepository.java
@@ -1,10 +1,23 @@
 package com.vip.interviewpartner.repository;
 
 import com.vip.interviewpartner.domain.RoomParticipant;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * RoomParticipant 엔티티에 대한 데이터 접근 리포지토리입니다.
  */
 public interface RoomParticipantRepository extends JpaRepository<RoomParticipant, Long> {
+    /**
+     * 주어진 멤버 ID를 기반으로 RoomParticipant 객체를 페이징하여 조회합니다.
+     * Room 엔티티를 함께 페치 조인(fetch join)하여 조회합니다.
+     *
+     * @param memberId 조회할 멤버의 ID
+     * @param pageable 페이징 정보
+     * @return 페이징된 RoomParticipant 객체 목록
+     */
+    @EntityGraph(attributePaths = {"room"})
+    Page<RoomParticipant> findByMemberId(Long memberId, Pageable pageable);
 }

--- a/server/src/main/java/com/vip/interviewpartner/service/ParticipantLookupService.java
+++ b/server/src/main/java/com/vip/interviewpartner/service/ParticipantLookupService.java
@@ -1,0 +1,79 @@
+package com.vip.interviewpartner.service;
+
+import com.vip.interviewpartner.domain.RoomParticipant;
+import com.vip.interviewpartner.dto.FeedbackCountDTO;
+import com.vip.interviewpartner.dto.PageCustom;
+import com.vip.interviewpartner.dto.ParticipationResponse;
+import com.vip.interviewpartner.repository.FeedbackRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * ParticipantLookupService 클래스는 멤버의 모의면접 참가 이력을 조회하는 비즈니스 로직을 처리합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ParticipantLookupService {
+    private final RoomParticipantService roomParticipantService;
+    private final FeedbackRepository feedbackRepository;
+
+    /**
+     * 주어진 멤버 ID로 모의면접 방 참가 이력을 조회하여 페이징된 ParticipationResponse 객체로 반환합니다.
+     *
+     * @param memberId 조회할 멤버의 ID
+     * @param pageable 페이징 정보
+     * @return 페이징된 ParticipationResponse 객체
+     */
+    public PageCustom<ParticipationResponse> getParticipation(Long memberId, Pageable pageable) {
+        Page<RoomParticipant> participants = roomParticipantService.findByMemberId(memberId, pageable);
+        List<Long> participantIds = extractParticipantIds(participants);
+        Map<Long, Long> feedbackCounts = getFeedbackCounts(participantIds);
+        Page<ParticipationResponse> page = createParticipationResponsePage(participants, feedbackCounts);
+        return new PageCustom<>(page);
+    }
+
+    /**
+     * 주어진 Page<RoomParticipant> 객체에서 참가자 ID를 추출하여 List<Long> 형태로 반환합니다.
+     *
+     * @param participants 참가자 페이지 객체
+     * @return 참가자 ID 목록
+     */
+    private List<Long> extractParticipantIds(Page<RoomParticipant> participants) {
+        return participants.stream()
+                .map(RoomParticipant::getId)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 주어진 참가자 ID 목록에 대한 피드백 수를 조회하여 Map<Long, Long> 형태로 반환합니다.
+     *
+     * @param participantIds 참가자 ID 목록
+     * @return 피드백 수 Map
+     */
+    private Map<Long, Long> getFeedbackCounts(List<Long> participantIds) {
+        List<FeedbackCountDTO> feedbackCountList = feedbackRepository.countFeedbacksByReceiverIds(participantIds);
+        return feedbackCountList.stream()
+                .collect(Collectors.toMap(FeedbackCountDTO::getReceiverId, FeedbackCountDTO::getCount));
+    }
+
+    /**
+     * 참가자 페이지 객체와 피드백 수 Map을 사용하여 ParticipationResponse 페이지 객체를 생성합니다.
+     *
+     * @param participants 참가자 페이지 객체
+     * @param feedbackCounts 피드백 수 Map
+     * @return ParticipationResponse 페이지 객체
+     */
+    private Page<ParticipationResponse> createParticipationResponsePage(Page<RoomParticipant> participants, Map<Long, Long> feedbackCounts) {
+        return participants.map(participant -> {
+            int feedbackCount = feedbackCounts.getOrDefault(participant.getId(), 0L).intValue();
+            return ParticipationResponse.of(participant, feedbackCount);
+        });
+    }
+}

--- a/server/src/main/java/com/vip/interviewpartner/service/RoomParticipantService.java
+++ b/server/src/main/java/com/vip/interviewpartner/service/RoomParticipantService.java
@@ -9,6 +9,8 @@ import com.vip.interviewpartner.domain.Room;
 import com.vip.interviewpartner.domain.RoomParticipant;
 import com.vip.interviewpartner.repository.RoomParticipantRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,5 +55,16 @@ public class RoomParticipantService {
     public RoomParticipant findRoomParticipant(Long participantId) {
         return roomParticipantRepository.findById(participantId)
                 .orElseThrow(() -> new CustomException(ROOM_PARTICIPANT_NOT_FOUND));
+    }
+
+    /**
+     * 주어진 멤버 ID로 RoomParticipant 객체 목록을 페이지로 조회합니다.
+     *
+     * @param memberId 조회할 멤버의 ID
+     * @param pageable 페이징 정보
+     * @return 페이징된 RoomParticipant 객체 목록
+     */
+    public Page<RoomParticipant> findByMemberId(Long memberId, Pageable pageable) {
+        return roomParticipantRepository.findByMemberId(memberId, pageable);
     }
 }


### PR DESCRIPTION
## Overview
- 자신의 모의면접 방 참가 이력을 조회하는 API 작성을 하였습니다.
- 응답에 참가정보와 더불어 참가한 방에서 받은 피드백 개수를 추가하였습니다.

## Change Log
- MemberController 수정
- FeedbackCountDTO, ParticipationResponse 추가
- RoomParticipantRepository, RoomParticipantRepository 수정
- ParticipantLookupService 추가

## To Reviewer
- 마이페이지 모의면접 참여이력에서 참가한 방 이름, 참가한 시각, 피드백 몇건 이 세개를 리스트에 보여주고, 자세한건 리스트에서 클릭해서 세부사항으로 보여줄 계획인데 의견있으시면 말씀해주세요

## Issue Tags
- Closed: #80 
