### PR TITLE
feat: 모의 면접 방 참여 이력 상세 조회 API 작성

### DIFF
--- a/server/src/main/java/com/vip/interviewpartner/controller/ParticipantController.java
+++ b/server/src/main/java/com/vip/interviewpartner/controller/ParticipantController.java
@@ -1,0 +1,48 @@
+package com.vip.interviewpartner.controller;
+
+import com.vip.interviewpartner.common.ApiCommonResponse;
+import com.vip.interviewpartner.dto.CustomUserDetails;
+import com.vip.interviewpartner.dto.ParticipantDetailsResponse;
+import com.vip.interviewpartner.service.RoomParticipantService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/participants")
+@Tag(name = "participants", description = "참가자 API")
+public class ParticipantController {
+
+    private final RoomParticipantService roomParticipantService;
+
+    /**
+     * 주어진 참가자 ID로 참가 이력의 상세 정보를 조회합니다.
+     *
+     * @param customUserDetails 현재 인증된 사용자의 세부 정보
+     * @param participantId 조회할 참가자 ID
+     * @return ApiCommonResponse<ParticipantDetailsResponse> 참가 이력의 상세 정보를 담은 응답 객체
+     */
+    @Operation(summary = "참가 이력 상세 조회 API",
+            description = "주어진 참가자 ID로 참가 이력의 상세 정보를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "참가 이력 조회 성공"),
+                    @ApiResponse(responseCode = "400", description = "유효하지 않은 참가자 ID", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content),
+            }
+    )
+    @GetMapping("/{participantId}")
+    public ApiCommonResponse<ParticipantDetailsResponse> getParticipantDetails(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                                               @PathVariable Long participantId) {
+        ParticipantDetailsResponse roomParticipantDetails = roomParticipantService.findRoomParticipantDetails(customUserDetails.getMemberId(), participantId);
+        return ApiCommonResponse.successResponse(roomParticipantDetails);
+    }
+}

--- a/server/src/main/java/com/vip/interviewpartner/dto/ParticipantDetailsResponse.java
+++ b/server/src/main/java/com/vip/interviewpartner/dto/ParticipantDetailsResponse.java
@@ -1,0 +1,73 @@
+package com.vip.interviewpartner.dto;
+
+import com.vip.interviewpartner.domain.Resume;
+import com.vip.interviewpartner.domain.Room;
+import com.vip.interviewpartner.domain.RoomParticipant;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * ParticipantDetailsResponse 클래스는 RoomParticipant, Room, Resume 엔티티의 상세 정보를 담는 DTO입니다.
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Schema(description = "방 참가 이력 상세 조회 응답 DTO")
+public class ParticipantDetailsResponse {
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+
+    @Schema(description = "방 제목", example = "네카라쿠배 면접 대비 방")
+    private String title;
+
+    @Schema(description = "방의 세부 설명", example = "이 방은 Java 면접 질문 연습을 위한 방입니다.")
+    private String details;
+
+    @Schema(description = "방의 최대 참가자 수", example = "4")
+    private Integer maxParticipants;
+
+    @Schema(description = "방에 연결된 태그 목록", example = "[\"Java\", \"면접\", \"연습\"]")
+    private List<String> tags;
+
+    @Schema(description = "참여한 이력서의 파일 이름", example = "resume.pdf")
+    private String originalFileName;
+
+    @Schema(description = "참여한 이력서의 파일 경로", example = "/files/resume.pdf")
+    private String filePath;
+
+    @Schema(description = "방 참가 날짜 및 시간", example = "2024.05.24 14:30")
+    private String joinDate;
+
+    @Schema(description = "방 퇴장 날짜 및 시간", example = "2024.05.24 15:30")
+    private String leaveDate;
+
+    /**
+     * RoomParticipant, Room, Resume 엔티티로부터 ParticipantDetailsResponse 객체를 생성합니다.
+     *
+     * @param participant RoomParticipant 엔티티
+     * @param room Room 엔티티
+     * @param resume Resume 엔티티
+     * @return 생성된 ParticipantDetailsResponse 객체
+     */
+    public static ParticipantDetailsResponse of(RoomParticipant participant, Room room, Resume resume) {
+        return ParticipantDetailsResponse.builder()
+                .title(room.getTitle())
+                .details(room.getDetails())
+                .maxParticipants(room.getMaxParticipants())
+                .tags(room.getRoomTags().stream()
+                        .map(roomTag -> roomTag.getTag().getName())
+                        .toList())
+                .originalFileName(resume.getOriginalFileName())
+                .filePath(resume.getFilePath())
+                .joinDate(Optional.ofNullable(participant.getJoinDate()).map(date -> date.format(formatter)).orElse(""))
+                .leaveDate(Optional.ofNullable(participant.getLeaveDate()).map(date -> date.format(formatter)).orElse(""))
+                .build();
+    }
+
+}

--- a/server/src/main/java/com/vip/interviewpartner/repository/RoomParticipantRepository.java
+++ b/server/src/main/java/com/vip/interviewpartner/repository/RoomParticipantRepository.java
@@ -1,10 +1,12 @@
 package com.vip.interviewpartner.repository;
 
 import com.vip.interviewpartner.domain.RoomParticipant;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 /**
  * RoomParticipant 엔티티에 대한 데이터 접근 리포지토리입니다.
@@ -20,4 +22,21 @@ public interface RoomParticipantRepository extends JpaRepository<RoomParticipant
      */
     @EntityGraph(attributePaths = {"room"})
     Page<RoomParticipant> findByMemberId(Long memberId, Pageable pageable);
+
+    /**
+     * 주어진 참가자 ID로 RoomParticipant 객체를 조회합니다.
+     * Room, RoomTags, Tag, Member, Resume 엔티티를 함께 페치 조인(fetch join)하여 조회합니다.
+     *
+     * @param id 조회할 RoomParticipant의 ID
+     * @return 조회된 RoomParticipant 객체, 존재하지 않을 경우 Optional.empty()
+     */
+    @Query("SELECT rp FROM RoomParticipant rp " +
+            "LEFT JOIN FETCH rp.room r " +
+            "LEFT JOIN FETCH r.roomTags rt " +
+            "LEFT JOIN FETCH rt.tag " +
+            "LEFT JOIN FETCH rp.member " +
+            "LEFT JOIN FETCH rp.resume " +
+            "WHERE rp.id = :id")
+    Optional<RoomParticipant> findWithDetailsById(Long id);
+
 }


### PR DESCRIPTION
## Overview
- 모의 면접 방 참여 이력 상세 조회하는 API를 작성하였습니다.
- 상세 조회 시 Member, Room, Resume 정보를 포함하기 위해 개별적으로 쿼리를 날리는 대신 fetch join을 사용하여 하나의 쿼리로 처리하였습니다.

## Change Log
- ParticipantController 추가
- RoomParticipantService 수정
- ParticipantDetailsResponse 추가
- RoomParticipantRepository 수정

## To Reviewer
- 코드의 fetch join 사용 부분과 전체적인 로직이 적절한지 확인 부탁드립니다.

## Issue Tags
- Closed: #92
