### PR TITLE
feat: 모의 면접 중 채팅창에서 면접 참여자들의 이력서를 확인할 수 있는 기능 구현 

### DIFF
--- a/client/src/pages/mockuproom/ResumeViewer.jsx
+++ b/client/src/pages/mockuproom/ResumeViewer.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const ResumeViewer = ({ resumeUrl }) => {
+    return (
+        <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+            <div style={{ flex: 1, overflow: 'hidden' }}>
+                <iframe
+                    src={`https://interviewpartnerbucket.s3.ap-northeast-2.amazonaws.com/${resumeUrl}`}
+                    style={{ width: '100%', height: '100%', border: 'none' }}
+                    title="User Resume"
+                ></iframe>
+            </div>
+        </div>
+    );
+};
+
+export default ResumeViewer;

--- a/client/src/pages/mockuproom/chatstyle.js
+++ b/client/src/pages/mockuproom/chatstyle.js
@@ -71,8 +71,10 @@ export const UserName = styled.span`
   font-size: 16px;
 `;
 
-export const UserResumeButton = styled.button`
-  background-color: rgba(255, 255, 255, 0.13);
+export const UserOptionButton = styled.button.attrs(props => ({
+  isActive: props.isActive,
+}))`
+  background-color: ${({ isActive }) => (isActive ? 'rgba(255, 255, 255, 0.3)' : 'rgba(255, 255, 255, 0.13)')};
   border: none;
   width: 40px;
   height: 40px;
@@ -95,29 +97,6 @@ export const UserResumeButton = styled.button`
   }
 `;
 
-export const UserFeedbackButton = styled.button`
-  background-color: rgba(255, 255, 255, 0.13);
-  border: none;
-  width: 40px;
-  height: 40px;
-  padding: 10px;
-  border-radius: 5px;
-  cursor: pointer;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  img {
-    width: 20px;
-    height: 20px;
-  }
-
-  transition: all 0.3s ease;
-
-  &:hover {
-    background-color: rgba(255, 255, 255, 0.3);
-  }
-`;
 
 export const ChatBox = styled.div`
   flex: 1;

--- a/client/src/pages/mockuproom/mockuproom.jsx
+++ b/client/src/pages/mockuproom/mockuproom.jsx
@@ -6,7 +6,7 @@ import voiceIcon from '../../assets/icons/voice_Icon.png';
 import headphoneIcon from '../../assets/icons/headphone_Icon.png';
 import callEndIcon from '../../assets/icons/call_end_Icon.png';
 import Chat from './chat';
-import { Container, VideoContainer, ButtonContainer, IconButton, IconImage, ChatIcon } from './mockuproomstyle';
+import { Container, VideoContainer, ButtonContainer, IconButton, IconImage, ToggleChatButton } from './mockuproomstyle';
 
 const MAX_PARTICIPANTS = 4;
 
@@ -205,7 +205,7 @@ function Mockuproom() {
           <IconImage src={callEndIcon} alt="Call End Icon" />
         </IconButton>
       </ButtonContainer>
-      {!isOpen && <ChatIcon onClick={toggleChat} />}
+      {!isOpen && <ToggleChatButton onClick={toggleChat} />}
       {shouldRender && (
         <Chat
           isOpen={isOpen}

--- a/client/src/pages/mockuproom/mockuproomstyle.js
+++ b/client/src/pages/mockuproom/mockuproomstyle.js
@@ -46,7 +46,7 @@ export const VideoContent = styled.div`
   height: 100%;
 `;
 
-export const ChatIcon = styled.div`
+export const ToggleChatButton = styled.div`
   position: fixed;
   bottom: 20px;
   right: 40px;


### PR DESCRIPTION
## Overview
- 면접 참여 시 본인 및 면접 참여자들이 선택했던 이력서(PDF파일)를 채팅창에서 확인할 수 있는 기능 구현하였습니다.
   
  ![image](https://github.com/interview-partner/interview-partner/assets/101254480/98e576eb-7a50-4400-966d-401cee7e63fc)


## Change Log
- chat.jsx 수정
- chatstyle.jsx 수정
- ResumeViewer.jsx 추가

## To Reviewer
- 이력서 버튼을 클릭하면 버튼의 색이 변하고 채팅창이 이력서뷰어로 전환됩니다. 다시 이력서버튼을 누르면 버튼의 색이 원래대로 돌아오고 이력서뷰어가 채팅창으로 전환됩니다.

## Issue Tags
- Closed: #95 
