### PR TITLE
feat: promptroom 질문 데이터 조회 api 적용

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -14,6 +14,7 @@ import Signup from "../src/pages/signup/signup.jsx";
 import Voiceroom from "../src/pages/voiceroom/voiceroom.jsx";
 import { AuthProvider } from './context/AuthContext.js';
 import { AccountProvider } from './context/accountContext';
+import { InterviewProvider } from './context/interviewContext'; // InterviewProvider import
 
 /**
  * 메인 애플리케이션 컴포넌트
@@ -23,29 +24,31 @@ function App() {
     <>
       <AuthProvider>
         <AccountProvider>
-          {/* 네비게이션 바 컴포넌트 */}
-          <Navbar />
-          {/* 라우트 설정 */}
-          <Routes>
-            {/* 메인 페이지 */}
-            <Route path="/" element={<Main />} />
-            {/* AI 면접 페이지 */}
-            <Route path="/aiinterview" element={<AIinterview />} />
-            {/* 프롬프트면접방 페이지 */}
-            <Route path="/promptroom" element={<Promptroom />} />
-            {/* 음성면접방 페이지 */}
-            <Route path="/voiceroom" element={<Voiceroom />} />
-            {/* 로그인 페이지 */}
-            <Route path="/login" element={<Login />} />
-            {/* 목업 커뮤니티 페이지 */}
-            <Route path="/mockupcommunity" element={<Mockupcommunity />} />
-            {/* 목업방 페이지 */}
-            <Route path="/mockuproom" element={<Mockuproom />} />
-            {/* 마이페이지 */}
-            <Route path="/mypage" element={<Mypage />} />
-            {/* 회원가입 페이지 */}
-            <Route path="/signup" element={<Signup />} />
-          </Routes>
+          <InterviewProvider> {/* InterviewProvider 추가 */}
+            {/* 네비게이션 바 컴포넌트 */}
+            <Navbar />
+            {/* 라우트 설정 */}
+            <Routes>
+              {/* 메인 페이지 */}
+              <Route path="/" element={<Main />} />
+              {/* AI 면접 페이지 */}
+              <Route path="/aiinterview" element={<AIinterview />} />
+              {/* 프롬프트면접방 페이지 */}
+              <Route path="/promptroom/:id" element={<Promptroom />} />
+              {/* 음성면접방 페이지 */}
+              <Route path="/voiceroom" element={<Voiceroom />} />
+              {/* 로그인 페이지 */}
+              <Route path="/login" element={<Login />} />
+              {/* 목업 커뮤니티 페이지 */}
+              <Route path="/mockupcommunity" element={<Mockupcommunity />} />
+              {/* 목업방 페이지 */}
+              <Route path="/mockuproom" element={<Mockuproom />} />
+              {/* 마이페이지 */}
+              <Route path="/mypage" element={<Mypage />} />
+              {/* 회원가입 페이지 */}
+              <Route path="/signup" element={<Signup />} />
+            </Routes>
+          </InterviewProvider> {/* InterviewProvider 닫기 */}
         </AccountProvider>
       </AuthProvider>
     </>

--- a/client/src/context/interviewContext.js
+++ b/client/src/context/interviewContext.js
@@ -1,0 +1,13 @@
+import React, { createContext, useState } from 'react';
+
+export const InterviewContext = createContext();
+
+export const InterviewProvider = ({ children }) => {
+  const [interviewId, setInterviewId] = useState(null);
+
+  return (
+    <InterviewContext.Provider value={{ interviewId, setInterviewId }}>
+      {children}
+    </InterviewContext.Provider>
+  );
+};

--- a/client/src/features/chat/interviewChat.jsx
+++ b/client/src/features/chat/interviewChat.jsx
@@ -1,105 +1,157 @@
-import React, { useState } from 'react';
-import { COLORS } from "../../styles/colors"
+import React, { useState, useEffect } from 'react';
+import { COLORS } from "../../styles/colors";
 import AIDialogBox from '../../components/textbox/aidialogBox.jsx';
 import styled from 'styled-components';
+import { getResumeInfo } from '../../services/getResumeInfoService';
 
 const ChatContainer = styled.div`
-    display: flex;
-    justify-content: center;
-    height: 100%;
-    width: 62.5%;
-    background-color: white;
+  display: flex;
+  justify-content: center;
+  height: 100%;
+  width: 62.5%;
+  background-color: white;
 `;
 
 const InnerContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    width: 80%;
-    overflow: hidden;
-    background-color: white;
-`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 80%;
+  overflow: hidden;
+  background-color: white;
+`;
 
 const MessagesContainer = styled.div`
-    flex: 1;
-    justify-content: center; 
-    align-items: center; 
-    justify-content: flex-end;
-    padding: 10px;
-    overflow-y: auto;
+  flex: 1;
+  justify-content: center; 
+  align-items: center; 
+  justify-content: flex-end;
+  padding: 10px;
+  overflow-y: auto;
 `;
 
 const InputContainer = styled.div`
-    display: flex;
-    margin-right: 80px;
-    margin-left: 80px;
-    gap: 4px;
-    padding: 10px;
+  display: flex;
+  margin-right: 80px;
+  margin-left: 80px;
+  gap: 4px;
+  padding: 10px;
 `;
 
 const Input = styled.input`
-    flex: 1;
-    padding: 10px;
-    border: 2px solid #D9D9D9;
-    border-radius: 10px;
+  flex: 1;
+  padding: 10px;
+  border: 2px solid #D9D9D9;
+  border-radius: 10px;
 `;
 
 const Button = styled.button`
-    display: flex;
-    margin-left: 10px;
-    padding: 10px;
-    border: none;
-    border-radius: 5px;
-    background-color: ${COLORS.blue_black};
-    color: white;
-    cursor: pointer;
+  display: flex;
+  margin-left: 10px;
+  padding: 10px;
+  border: none;
+  border-radius: 5px;
+  background-color: ${COLORS.blue_black};
+  color: white;
+  cursor: pointer;
 `;
 
-const InterviewChat = () => {
-    const [messages, setMessages] = useState([
-        { text: "안녕하세요, 어떻게 도와드릴까요?", isUser: false }
-    ]);
-    const [input, setInput] = useState('');
+const InterviewChat = ({ interviewId }) => {
+  const [messages, setMessages] = useState([
+    { text: "안녕하세요, AI 면접을 시작합니다.\n준비가 되셨다면 채팅창에 '시작' 을 보내주세요 :)", isUser: false }
+  ]);
+  const [input, setInput] = useState('');
+  const [questions, setQuestions] = useState([]);
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
+  const [hasStarted, setHasStarted] = useState(false);
 
-    const handleSend = () => {
-        if (input.trim()) {
-            setMessages([...messages, { text: input, isUser: true }]);
-            setInput('');
-            setTimeout(() => {
-                setMessages((prevMessages) => [
-                    ...prevMessages,
-                    { text: "다음 질문입니다. ...", isUser: false }
-                ]);
-            }, 1000);
+  useEffect(() => {
+    console.log("Interview ID: ", interviewId); // 현재 Interview ID 확인
+    if (interviewId) {
+      const fetchQuestions = async () => {
+        try {
+          const response = await getResumeInfo(interviewId);
+          if (response && response.data) {
+            setQuestions(response.data);
+          } else {
+            throw new Error("No data received");
+          }
+        } catch (error) {
+          console.error('질문을 가져오는 중 오류 발생:', error.message);
+          setMessages(prevMessages => [
+            ...prevMessages,
+            { text: "질문 데이터를 불러오는 중 문제가 발생했습니다. 다시 시도해 주세요.", isUser: false }
+          ]);
         }
-    };
+      };
+      fetchQuestions();
+    } else {
+      setMessages(prevMessages => [
+        ...prevMessages,
+        { text: "인터뷰 ID가 제공되지 않았습니다.", isUser: false }
+      ]);
+    }
+  }, [interviewId]);
 
-    return (
-        <ChatContainer>
-            <InnerContainer>
-            <MessagesContainer>
-                {messages.map((message, index) => (
-                    <AIDialogBox key={index} text={message.text} isUser={message.isUser} />
-                ))}
-            </MessagesContainer>
-            <InputContainer>
-                <Input
-                    type="text"
-                    value={input}
-                    onChange={(e) => setInput(e.target.value)}
-                    onKeyPress={(e) => {
-                        if (e.key === 'Enter') handleSend();
-                    }}
-                />
-                <Button onClick={handleSend}>
-                    <span class="material-symbols-outlined">
-                        send
-                    </span>
-                </Button>
-            </InputContainer>
-            </InnerContainer>
-        </ChatContainer>
-    );
+  const handleSend = () => {
+    if (input.trim()) {
+      const newMessages = [...messages, { text: input, isUser: true }];
+      setMessages(newMessages);
+      setInput('');
+
+      setTimeout(() => {
+        if (input.trim() === "시작" && !hasStarted) {
+          setHasStarted(true);
+          sendNextQuestion();
+        } else if (hasStarted) {
+          sendNextQuestion();
+        }
+      }, 1000);
+    }
+  };
+
+  const sendNextQuestion = () => {
+    if (currentQuestionIndex < questions.length) {
+      setMessages(prevMessages => [
+        ...prevMessages,
+        { text: questions[currentQuestionIndex].content, isUser: false }
+      ]);
+      setCurrentQuestionIndex(currentQuestionIndex + 1);
+    } else if (hasStarted) {
+      setMessages(prevMessages => [
+        ...prevMessages,
+        { text: "인터뷰가 종료되었습니다. 수고하셨습니다.", isUser: false }
+      ]);
+      setHasStarted(false);  // Reset interview state
+    }
+  };
+
+  return (
+    <ChatContainer>
+      <InnerContainer>
+        <MessagesContainer>
+          {messages.map((message, index) => (
+            <AIDialogBox key={index} text={message.text} isUser={message.isUser} />
+          ))}
+        </MessagesContainer>
+        <InputContainer>
+          <Input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyPress={(e) => {
+              if (e.key === 'Enter') handleSend();
+            }}
+          />
+          <Button onClick={handleSend}>
+            <span className="material-symbols-outlined">
+              send
+            </span>
+          </Button>
+        </InputContainer>
+      </InnerContainer>
+    </ChatContainer>
+  );
 };
 
 export default InterviewChat;

--- a/client/src/features/input/InputInterviewInfo.jsx
+++ b/client/src/features/input/InputInterviewInfo.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import styled, { keyframes, css } from 'styled-components';
 import { COLORS } from "../../styles/colors";
 import RoundButton from '../../components/button/RoundButton';
@@ -7,6 +7,8 @@ import InputPersonalInfo from '../../features/input/InputPersonalInfo';
 import InputResumeSelect from '../../features/input/InputResumeSelect';
 import InputReady from './Inputready';
 import { createInterviewRoom } from '../../services/interviewService';
+import { useNavigate } from 'react-router-dom';
+import { InterviewContext } from '../../context/interviewContext';
 
 const fadeIn = keyframes`
   from {
@@ -42,7 +44,6 @@ const Carousel = styled.div`
   width: 90%;
   height: 628px;
   position: relative;
-
   &::before, &::after {
     content: '';
     position: absolute;
@@ -51,12 +52,10 @@ const Carousel = styled.div`
     width: 100px;
     z-index: 1;
   }
-
   &::before {
     left: 0;
     background: linear-gradient(to right, white, transparent);
   }
-
   &::after {
     right: 0;
     background: linear-gradient(to left, white, transparent);
@@ -100,7 +99,8 @@ const ButtonContainer = styled.div`
   `}
 `;
 
-function InputInterviewInfo({ currentIndex, setCurrentIndex }) {
+function InputInterviewInfo() {
+  const [currentIndex, setCurrentIndex] = useState(0);
   const [interviewData, setInterviewData] = useState({
     title: '',
     interviewType: '',
@@ -108,26 +108,30 @@ function InputInterviewInfo({ currentIndex, setCurrentIndex }) {
     jobAdvertisement: '',
     resumeId: null
   });
+  const navigate = useNavigate();
+  const { setInterviewId } = useContext(InterviewContext);
 
   const nextCard = () => {
-    if (currentIndex < 3) {
-      setCurrentIndex(currentIndex + 1);
-    }
+    if (currentIndex < 3) setCurrentIndex(currentIndex + 1);
   };
 
   const prevCard = () => {
-    if (currentIndex > 0) {
-      setCurrentIndex(currentIndex - 1);
-    }
+    if (currentIndex > 0) setCurrentIndex(currentIndex - 1);
   };
 
   const handleCreateInterview = async () => {
     try {
       const response = await createInterviewRoom(interviewData);
-      alert('Interview room created successfully!');
-      console.log('Created interview room:', response);
+      if (response && response.status === 'success' && response.data) {
+        const interviewId = response.data;
+        setInterviewId(interviewId); // Interview ID 설정
+        localStorage.setItem('interviewData', JSON.stringify(interviewData));
+        navigate(`/promptroom/${interviewId}`);
+      } else {
+        throw new Error("Invalid response from server.");
+      }
     } catch (error) {
-      alert(`Failed to create interview room: ${error.message}`);
+      console.error('Failed to create interview room:', error);
     }
   };
 
@@ -138,21 +142,10 @@ function InputInterviewInfo({ currentIndex, setCurrentIndex }) {
           <Card>
             <InputInterviewSetting interviewData={interviewData} setInterviewData={setInterviewData} />
             <ButtonContainer isVisible={currentIndex === 0}>
-              <RoundButton
-                onClick={prevCard}
-                disabled={currentIndex === 0}
-                color="white"
-                bgColor={COLORS.blue_black}
-                style={{ visibility: currentIndex === 0 ? 'hidden' : 'visible' }}
-              >
+              <RoundButton onClick={prevCard} disabled={currentIndex === 0} color="white" bgColor={COLORS.blue_black}>
                 이전
               </RoundButton>
-              <RoundButton
-                onClick={nextCard}
-                disabled={currentIndex === 3}
-                color="white"
-                bgColor={COLORS.blue_black}
-              >
+              <RoundButton onClick={nextCard} disabled={currentIndex === 3} color="white" bgColor={COLORS.blue_black}>
                 다음
               </RoundButton>
             </ButtonContainer>
@@ -160,21 +153,10 @@ function InputInterviewInfo({ currentIndex, setCurrentIndex }) {
           <Card>
             <InputPersonalInfo interviewData={interviewData} setInterviewData={setInterviewData} />
             <ButtonContainer isVisible={currentIndex === 1}>
-              <RoundButton
-                onClick={prevCard}
-                disabled={currentIndex === 0}
-                color="white"
-                bgColor={COLORS.blue_black}
-                style={{ visibility: currentIndex === 0 ? 'hidden' : 'visible' }}
-              >
+              <RoundButton onClick={prevCard} color="white" bgColor={COLORS.blue_black}>
                 이전
               </RoundButton>
-              <RoundButton
-                onClick={nextCard}
-                disabled={currentIndex === 3}
-                color="white"
-                bgColor={COLORS.blue_black}
-              >
+              <RoundButton onClick={nextCard} color="white" bgColor={COLORS.blue_black}>
                 다음
               </RoundButton>
             </ButtonContainer>
@@ -182,40 +164,23 @@ function InputInterviewInfo({ currentIndex, setCurrentIndex }) {
           <Card>
             <InputResumeSelect interviewData={interviewData} setInterviewData={setInterviewData} />
             <ButtonContainer isVisible={currentIndex === 2}>
-              <RoundButton
-                onClick={prevCard}
-                disabled={currentIndex === 0}
-                color="white"
-                bgColor={COLORS.blue_black}
-                style={{ visibility: currentIndex === 0 ? 'hidden' : 'visible' }}
-              >
+              <RoundButton onClick={prevCard} color="white" bgColor={COLORS.blue_black}>
                 이전
               </RoundButton>
-              <RoundButton
-                onClick={nextCard}
-                disabled={currentIndex === 3}
-                color="white"
-                bgColor={COLORS.blue_black}
-              >
+              <RoundButton onClick={nextCard} color="white" bgColor={COLORS.blue_black}>
                 다음
               </RoundButton>
             </ButtonContainer>
           </Card>
           <Card>
-            <InputReady 
-              interviewData={interviewData} 
-              setInterviewData={setInterviewData} 
-              handleCreateInterview={handleCreateInterview} 
+            <InputReady
+              interviewData={interviewData}
+              setInterviewData={setInterviewData}
+              onStartInterview={handleCreateInterview}
               currentIndex={currentIndex}
             />
             <ButtonContainer isVisible={currentIndex === 3}>
-              <RoundButton
-                onClick={prevCard}
-                disabled={currentIndex === 0}
-                color="white"
-                bgColor={COLORS.blue_black}
-                style={{ visibility: currentIndex === 0 ? 'hidden' : 'visible' }}
-              >
+              <RoundButton onClick={prevCard} color="white" bgColor={COLORS.blue_black}>
                 이전
               </RoundButton>
             </ButtonContainer>

--- a/client/src/features/input/InputInterviewSetting.jsx
+++ b/client/src/features/input/InputInterviewSetting.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { COLORS } from "../../styles/colors";
-import SmallsquareButton from '../../components/button/SmallsquareButton';
+import SmallsquareButton from '../../components/button/smallsquareButton';
 import CounterButton from '../../components/button/counterButton'; 
 import CounterOne from "../../assets/icons/counter_1.png";
 import CounterTwo from "../../assets/icons/counter_2.png";

--- a/client/src/features/input/InputInterviewSetting.jsx
+++ b/client/src/features/input/InputInterviewSetting.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { COLORS } from "../../styles/colors";
-import SmallsquareButton from '../../components/button/smallsquareButton';
+import SmallsquareButton from '../../components/button/SmallsquareButton';
 import CounterButton from '../../components/button/counterButton'; 
 import CounterOne from "../../assets/icons/counter_1.png";
 import CounterTwo from "../../assets/icons/counter_2.png";

--- a/client/src/features/input/Inputready.jsx
+++ b/client/src/features/input/Inputready.jsx
@@ -4,7 +4,6 @@ import { COLORS } from "../../styles/colors";
 import Circle from "../../assets/icons/circle.png";
 import CheckMethod from "../../assets/images/checkMethodType.png";
 import BigSquareButton from "../../components/button/bigsquareButton";
-import { useNavigate } from 'react-router-dom';
 
 const Container = styled.div`
   width: 100%;
@@ -63,19 +62,7 @@ const Img = styled.img`
   height: 133px;
 `;
 
-function InputReady({ interviewData, setInterviewData, handleCreateInterview, currentIndex }) {
-  const navigate = useNavigate();
-
-  const handleButtonClick = async () => {
-    try {
-      await handleCreateInterview();
-      localStorage.setItem('interviewData', JSON.stringify(interviewData));
-      navigate('/promptroom');
-    } catch (error) {
-      console.error('Failed to create interview room:', error);
-    }
-  };
-
+function InputReady({ onStartInterview, currentIndex }) {
   return (
     <Container>
       <Title>면접 준비</Title>
@@ -97,7 +84,7 @@ function InputReady({ interviewData, setInterviewData, handleCreateInterview, cu
           </GuideList>
         </GuideContainer>
         <BigSquareButton 
-          onClick={handleButtonClick} 
+          onClick={onStartInterview} 
           disabled={currentIndex !== 3}
         >
           면접 시작하기

--- a/client/src/pages/promptroom/promptroom.jsx
+++ b/client/src/pages/promptroom/promptroom.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
-import InterviewChat from "../../features/chat/interviewChat.jsx";
-import InterviewInfo from "../../features/banner/interviewInfo.jsx";
+import { useParams } from 'react-router-dom';
+import InterviewChat from "../../features/chat/interviewChat";
+import InterviewInfo from "../../features/banner/interviewInfo";
 
 const PromptroomContainer = styled.div`
   display: flex;
@@ -12,10 +13,13 @@ const PromptroomContainer = styled.div`
 `;
 
 function Promptroom() {
+  const { id } = useParams();
+  const interviewId = parseInt(id, 10);
+
   return (
     <PromptroomContainer>
       <InterviewInfo />
-      <InterviewChat />
+      {interviewId ? <InterviewChat interviewId={interviewId} /> : <div>Loading...</div>}
     </PromptroomContainer>
   );
 }

--- a/client/src/services/getResumeInfoService.js
+++ b/client/src/services/getResumeInfoService.js
@@ -1,35 +1,32 @@
 import api from './axiosConfig';
 
 /**
- * 인터뷰 방을 생성하는 함수
+ * 사용자의 이력서와 관련된 질문 리스트를 조회하는 함수
  * 
- * @param {Object} interviewData - 인터뷰 방 생성에 필요한 데이터
- * @param {string} interviewData.title - 인터뷰 제목
- * @param {string} interviewData.interviewType - 인터뷰 유형 (예: 텍스트)
- * @param {number} interviewData.questionNumber - 질문 수
- * @param {string} interviewData.jobAdvertisement - 직무 광고
- * @param {number} interviewData.resumeId - 이력서 ID
- * @returns {Promise<Object>} - 생성된 인터뷰 방 데이터 반환
+ * @param {number|string} interviewsId - 인터뷰 ID
+ * @returns {Promise<Object>} - 이력서 및 질문 리스트 조회 결과 반환
  * @throws {Error} - 오류 발생 시 오류 메시지 반환
  */
-export const createInterviewRoom = async (interviewData) => {
-    try {
-        const response = await api.post('/interviews', interviewData, {
-            headers: {
-                'Content-Type': 'application/json;charset=UTF-8',
-            }
-        });
-        console.log('Server response:', response.data);  // 서버 응답 확인
-        return response.data;  // 응답 데이터 반환
-    } catch (error) {
-        let errorMessage = "Unknown error occurred";
-        if (error.response && error.response.status === 400) {
-            errorMessage = "유효하지 않은 형식입니다.";
-        } else if (error.response && error.response.status === 401) {
-            errorMessage = "인증 실패";
-        }
-        throw new Error(errorMessage);
+export const getResumeInfo = async (interviewsId) => {
+  try {
+    const response = await api.get(`/interviews/${interviewsId}/questions`);
+    return response.data;
+  } catch (error) {
+    let errorMessage = '이력서 정보 조회 중 오류가 발생했습니다.';
+    if (error.response) {
+      const { status } = error.response;
+      if (status === 400) {
+        errorMessage = '요청 형식이 잘못되었습니다.';
+      } else if (status === 401) {
+        errorMessage = '인증 실패';
+      } else if (status === 404) {
+        errorMessage = '이력서 정보를 찾을 수 없습니다.';
+      } else if (status === 500) {
+        errorMessage = '서버에 문제가 발생했습니다.';
+      }
     }
+    throw new Error(errorMessage);
+  }
 };
 
-export default createInterviewRoom;
+export default getResumeInfo;

--- a/client/src/services/getResumeInfoService.js
+++ b/client/src/services/getResumeInfoService.js
@@ -1,0 +1,35 @@
+import api from './axiosConfig';
+
+/**
+ * 인터뷰 방을 생성하는 함수
+ * 
+ * @param {Object} interviewData - 인터뷰 방 생성에 필요한 데이터
+ * @param {string} interviewData.title - 인터뷰 제목
+ * @param {string} interviewData.interviewType - 인터뷰 유형 (예: 텍스트)
+ * @param {number} interviewData.questionNumber - 질문 수
+ * @param {string} interviewData.jobAdvertisement - 직무 광고
+ * @param {number} interviewData.resumeId - 이력서 ID
+ * @returns {Promise<Object>} - 생성된 인터뷰 방 데이터 반환
+ * @throws {Error} - 오류 발생 시 오류 메시지 반환
+ */
+export const createInterviewRoom = async (interviewData) => {
+    try {
+        const response = await api.post('/interviews', interviewData, {
+            headers: {
+                'Content-Type': 'application/json;charset=UTF-8',
+            }
+        });
+        console.log('Server response:', response.data);  // 서버 응답 확인
+        return response.data;  // 응답 데이터 반환
+    } catch (error) {
+        let errorMessage = "Unknown error occurred";
+        if (error.response && error.response.status === 400) {
+            errorMessage = "유효하지 않은 형식입니다.";
+        } else if (error.response && error.response.status === 401) {
+            errorMessage = "인증 실패";
+        }
+        throw new Error(errorMessage);
+    }
+};
+
+export default createInterviewRoom;

--- a/client/src/services/interviewService.js
+++ b/client/src/services/interviewService.js
@@ -14,37 +14,22 @@ import api from './axiosConfig';
  */
 export const createInterviewRoom = async (interviewData) => {
     try {
-        /**
-         * 인터뷰 방 생성 API 요청
-         */
         const response = await api.post('/interviews', interviewData, {
             headers: {
                 'Content-Type': 'application/json;charset=UTF-8',
             }
         });
-
-        /**
-         * 생성된 인터뷰 방 데이터 반환
-         */
-        return response.data;
+        console.log('Server response:', response.data);  // 서버 응답 확인
+        return response.data;  // 응답 데이터 반환
     } catch (error) {
-        /**
-         * 오류 메시지 기본값 설정
-         */
         let errorMessage = "Unknown error occurred";
-
-        /**
-         * 오류 응답에 따라 오류 메시지 설정
-         */
         if (error.response && error.response.status === 400) {
             errorMessage = "유효하지 않은 형식입니다.";
         } else if (error.response && error.response.status === 401) {
             errorMessage = "인증 실패";
         }
-
-        /**
-         * 오류 메시지 포함된 에러 던지기
-         */
         throw new Error(errorMessage);
     }
 };
+
+export default createInterviewRoom;


### PR DESCRIPTION
## Overview
- 
<img width="1280" alt="promptapi" src="https://github.com/interview-partner/interview-partner/assets/126398267/31c10903-dd6a-431f-bc99-bd98f05217f2">


## Change Log
- services/interviewService.js의 로직을 수정하였습니다
- services/getResumeInfoService.js에 이력서 질문 리스트를 받아오는 서비스를 구현하였습니다
- features/input/inputready.jsx 컴포넌트를 통해 인터뷰 방 생성을 시작하도록 로직을 수정하였습니다
- features/input/inputInterviewInfo.jsx 컴포넌트에 interviewService와 interviewContext를 적용하였습니다
- context/interviewContext.js에 interviewID 데이터를 전역으로 저장하기 위한 Context를 구현하였습니다
- App.js에 interviewContext를 적용한 InterviewProvider를 구현하여 적용하였습니다
- App.js에 promptroom 라우팅을 동적으로 설정하였습니다
- promptroom/promptroom.jsx에서 interviewId를 interviewChat에 전달할 수 있도록 로직을 수정하였습니다
- chat/interviewChat.jsx에 getResumeInfoService를 적용하였습니다
- client/src/features/input/InputInterviewSetting.jsx파일의
import SmallsquareButton from '../../components/button/SmallsquareButton'; 을
SmallsquareButton -> smallsquareButton 로 수정하여 경로 설정 오류를 해결하였습니다

## To Reviewer
- promptroom의 banner 데이터는 아직 구현하지 않았습니다. 이력서 질문 데이터 적용을 위주로 확인해주세요.

## Issue Tags
- Closed: #105 
