### PR TITLE
chore: build.gradle 누락된 설정 추가

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -62,7 +62,7 @@ processResources.dependsOn('copySecret')
 
 task copySecret(type: Copy) {
 	from 'src/main/resources/secret'
-	include 'application.yml', 'application-prod.yml', 'application-dev.yml', 'application-local.yml', 'serviceAccountKey.json'
+	include 'application.yml', 'application-prod.yml', 'application-dev.yml', 'application-local.yml', 'serviceAccountKey.json', 'interview-partner-google-cloud.json'
 	into 'src/main/resources'
 }
 


### PR DESCRIPTION
## Overview
- build.gradle 에 git submoudles 설정에  interview-partner-google-cloud.json  가 누락 된 것을 추가하였습니다.

## Change Log
- build.gradle 수정

## To Reviewer
- 

## Issue Tags
- Closed: #132
